### PR TITLE
New Connection Wizard Step Content Not Showing

### DIFF
--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
@@ -129,8 +129,6 @@ export class AddConnectionWizardComponent implements OnInit {
       loadingTitle: "Add Connection Wizard loading",
       loadingSecondaryInfo: "Please wait for the wizard to finish loading...",
       title: "Add Connection",
-      sidebarStyleClass: "example-wizard-sidebar",
-      stepStyleClass: "example-wizard-step"
     } as WizardConfig;
 
     // Load the templates for the first step

--- a/src/main/ngapp/src/index.html
+++ b/src/main/ngapp/src/index.html
@@ -8,8 +8,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.23.1/css/patternfly.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.23.1/css/patternfly-additions.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.28.3/css/patternfly.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.28.3/css/patternfly-additions.min.css">
 
 </head>
 <body>


### PR DESCRIPTION
- We updated Patternfly but forgot to update the Patternfly CSS links to the new version. Now the connection wizard pages are showing.
- Removed the connection wizard sidebar and step classes from the wizard config. These values we were using did not exist and the defaults seem to be working fine for now.