### PR TITLE
Make Property Control Type an Enum

### DIFF
--- a/src/main/ngapp/src/app/shared/property-form/property-control-type.enum.ts
+++ b/src/main/ngapp/src/app/shared/property-form/property-control-type.enum.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PropertyDefinition } from "@shared/property-form/property-definition.model";
+
+/**
+ * An enumeration of control types for a property.
+ */
+
+export enum PropertyControlType {
+
+  /**
+   * Render the property as a checkbox.
+   */
+  CHECKBOX,
+
+  /**
+   * Render the property as a dropdown.
+   */
+  DROPDOWN,
+
+  /**
+   * Render the property as a masked textbox.
+   */
+  PASSWORD,
+
+  /**
+   * Render the property as a textbox.
+   */
+  TEXT
+
+}
+
+/**
+ * Namespace to allow methods on the enum.
+ */
+export namespace PropertyControlType {
+
+  /**
+   * @param {PropertyDefinition<any>} propDefn the property whose control type is being requested
+   * @returns {PropertyControlType} the control type to render the property value
+   */
+  export function toControlType( propDefn: PropertyDefinition< any > ): PropertyControlType {
+    if ( propDefn.isConstrainedToAllowedValues() ) {
+      return PropertyControlType.DROPDOWN;
+    }
+
+    if ( propDefn.getTypeClassName() === "java.lang.Boolean" ) {
+      return PropertyControlType.CHECKBOX;
+    }
+
+    if ( propDefn.isMasked() || propDefn.getId() === "password" ) {
+      return PropertyControlType.PASSWORD;
+    }
+
+    // defaults to a text control
+    return PropertyControlType.TEXT;
+  }
+
+}

--- a/src/main/ngapp/src/app/shared/property-form/property-definition.model.ts
+++ b/src/main/ngapp/src/app/shared/property-form/property-definition.model.ts
@@ -95,24 +95,6 @@ export class PropertyDefinition<T> {
   }
 
   /**
-   * @returns {string} the type of control for this property definition
-   */
-  public getControlType(): string {
-    const className = this.getTypeClassName();
-    if (this.isConstrainedToAllowedValues()) {
-      return "dropdown";
-    } else if (className === "java.lang.String") {
-      if (this.isMasked() || this.getId() === "password") {
-        return "maskedTextbox";
-      }
-      return "textbox";
-    } else if (className === "java.lang.Boolean") {
-      return "checkbox";
-    }
-    return "textbox";
-  }
-
-  /**
    * @returns {boolean} 'true' if required
    */
   public isRequired(): boolean {

--- a/src/main/ngapp/src/app/shared/property-form/property-form-property/property-form-property.component.html
+++ b/src/main/ngapp/src/app/shared/property-form/property-form-property/property-form-property.component.html
@@ -1,18 +1,18 @@
 <div [ngClass]="isValid ? 'form-group' : 'form-group has-error'" [formGroup]="form">
   <label class="col-md-2 control-label" [attr.for]="property.getId()" data-toggle="tooltip" [title]="property.getDescription()">{{ property.getDisplayName() }}</label>
 
-  <div class="col-md-10" [ngSwitch]="property.getControlType()">
+  <div class="col-md-10" [ngSwitch]="controlType.toControlType(property)">
 
-    <input *ngSwitchCase="'textbox'" class="form-control" [formControlName]="property.getId()"
+    <input *ngSwitchCase="controlType.TEXT" class="form-control" [formControlName]="property.getId()"
            [id]="property.getId()" type="text" title="A text value">
 
-    <input *ngSwitchCase="'maskedTextbox'" class="form-control" [formControlName]="property.getId()"
+    <input *ngSwitchCase="controlType.PASSWORD" class="form-control" [formControlName]="property.getId()"
            [id]="property.getId()" type="password" title="A text value">
 
-    <input *ngSwitchCase="'checkbox'" [formControlName]="property.getId()"
+    <input *ngSwitchCase="controlType.CHECKBOX" [formControlName]="property.getId()"
            [id]="property.getId()" type="checkbox" title="A boolean value">
 
-    <select [id]="property.getId()" *ngSwitchCase="'dropdown'" [(ngModel)]="property.theDefaultValue" class="form-control"
+    <select [id]="property.getId()" *ngSwitchCase="controlType.DROPDOWN" [(ngModel)]="property.theDefaultValue" class="form-control"
             [formControlName]="property.getId()" title="A value with allowed values">
       <option *ngFor="let allowedValue of property.getAllowedValues()" [selected]="allowedValue === property.theDefaultValue" [value]="allowedValue">{{ allowedValue }}</option>
     </select>

--- a/src/main/ngapp/src/app/shared/property-form/property-form-property/property-form-property.component.ts
+++ b/src/main/ngapp/src/app/shared/property-form/property-form-property/property-form-property.component.ts
@@ -19,6 +19,7 @@ import { Component, Input } from "@angular/core";
 import { AbstractControl, FormGroup } from "@angular/forms";
 
 import { PropertyDefinition } from "@shared/property-form/property-definition.model";
+import { PropertyControlType } from "@shared/property-form/property-control-type.enum";
 
 @Component({
   selector: "app-form-property",
@@ -26,6 +27,8 @@ import { PropertyDefinition } from "@shared/property-form/property-definition.mo
 })
 
 export class PropertyFormPropertyComponent {
+
+  public controlType = PropertyControlType; // need local ref of enum for html to use
 
   @Input() public property: PropertyDefinition<any>;
   @Input() public form: FormGroup;

--- a/src/main/ngapp/tslint.json
+++ b/src/main/ngapp/tslint.json
@@ -91,6 +91,7 @@
       "ignore-params"
     ],
     "no-misused-new": true,
+    "no-namespace": false,
     "no-non-null-assertion": true,
     "no-parameter-properties": true,
     "no-shadowed-variable": true,


### PR DESCRIPTION
- created an enum for a property definition control type
- moved the getControlType() function from the property definition model into the PropertyControlType enum
- changed html switch to use the enum