### PR TITLE
Update karma.conf.js

### DIFF
--- a/src/main/ngapp/karma.conf.js
+++ b/src/main/ngapp/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function (config) {
     angularCli: {
       environment: 'dev'
     },
-    reporters: ['junit'],
+    reporters: ['junit', 'progress'],
     autoWatch: false,
     browsers: [ 'PhantomJS' ],
     singleRun: true


### PR DESCRIPTION
Adding back 'progress' as one of the "reporters" so that when running `ng test` in a terminal you get feedback on test executions and pass/fails.