### PR TITLE
Updates dataservice creation process

### DIFF
--- a/src/main/ngapp/src/app/activities/activities.component.ts
+++ b/src/main/ngapp/src/app/activities/activities.component.ts
@@ -101,6 +101,7 @@ export class ActivitiesComponent extends AbstractPageComponent {
     this.confirmDeleteDialog.open();
   }
 
+  // noinspection JSMethodCanBeStatic
   public onStart(activityName: string): void {
     alert("Start activity " + activityName);
   }

--- a/src/main/ngapp/src/app/activities/shared/activity.service.spec.ts
+++ b/src/main/ngapp/src/app/activities/shared/activity.service.spec.ts
@@ -1,17 +1,18 @@
 import { ActivityService } from "@activities/shared/activity.service";
 import { inject, TestBed } from "@angular/core/testing";
 import { HttpModule } from "@angular/http";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 
 describe("ActivityService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpModule ],
-      providers: [ActivityService, LoggerService]
+      providers: [ActivityService, AppSettingsService, LoggerService]
     });
   });
 
-  it("should be created", inject([ActivityService, LoggerService],
+  it("should be created", inject([ActivityService, AppSettingsService, LoggerService],
                                             (service: ActivityService, logger: LoggerService) => {
     expect(service).toBeTruthy();
   }));

--- a/src/main/ngapp/src/app/activities/shared/activity.service.ts
+++ b/src/main/ngapp/src/app/activities/shared/activity.service.ts
@@ -20,6 +20,7 @@ import { NewActivity } from "@activities/shared/new-activity.model";
 import { Injectable } from "@angular/core";
 import { Http } from "@angular/http";
 import { ApiService } from "@core/api.service";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import "rxjs/add/observable/of";
 import { Observable } from "rxjs/Observable";
@@ -29,8 +30,8 @@ export class ActivityService extends ApiService {
 
   private http: Http;
 
-  constructor( http: Http, logger: LoggerService ) {
-    super( logger );
+  constructor( http: Http, appSettings: AppSettingsService, logger: LoggerService ) {
+    super( appSettings, logger );
     this.http = http;
   }
 

--- a/src/main/ngapp/src/app/activities/shared/mock-activity.service.ts
+++ b/src/main/ngapp/src/app/activities/shared/mock-activity.service.ts
@@ -1,9 +1,27 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Activity } from "@activities/shared/activity.model";
 import { ActivityService } from "@activities/shared/activity.service";
 import { NewActivity } from "@activities/shared/new-activity.model";
 import { Injectable } from "@angular/core";
 import { Http } from "@angular/http";
 import { NewConnection } from "@connections/shared/new-connection.model";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import "rxjs/add/observable/of";
 import "rxjs/add/observable/throw";
@@ -20,8 +38,8 @@ export class MockActivityService extends ActivityService {
   private acts: Activity[] = [this.act1, this.act2, this.act3];
   private newAct1 = new NewActivity();
 
-  constructor( http: Http, logger: LoggerService ) {
-    super(http, logger);
+  constructor( http: Http, appSettings: AppSettingsService, logger: LoggerService ) {
+    super(http, appSettings, logger);
     this.act1.setId("activity1");
     this.act1.setSourceConnection("activity1SrcConn");
     this.act1.setTargetConnection("activity1TgtConn");

--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
@@ -356,7 +356,15 @@ export class AddConnectionWizardComponent implements OnInit {
    * @returns {boolean} 'true' if connection is JDBC
    */
   public get isJdbc(): boolean {
-    return true;
+    const driver = this.connectionDriverName;
+    let jdbc = true;
+    // TODO: this needs to be a hooked up to komodo call instead
+    if (driver === null || driver === "cassandra" || driver === "file" || driver === "google"
+                        || driver === "ldap" || driver === "mongodb" || driver === "salesforce"
+                        || driver === "salesforce-34" || driver === "solr" || driver === "webservice") {
+      jdbc = false;
+    }
+    return jdbc;
   }
 
   // ----------------

--- a/src/main/ngapp/src/app/connections/shared/connection.model.ts
+++ b/src/main/ngapp/src/app/connections/shared/connection.model.ts
@@ -23,6 +23,7 @@ export class Connection implements Identifiable< string > {
   private keng__id: string;
   private dv__jndiName: string;
   private dv__driverName: string;
+  private dv__type: boolean;
   private keng__properties: Map< string, string > = new Map< string, string >();
 
   /**
@@ -100,6 +101,13 @@ export class Connection implements Identifiable< string > {
   }
 
   /**
+   * @returns {boolean} the jdbc status (true == jdbc)
+   */
+  public isJdbc(): boolean {
+    return this.dv__type;
+  }
+
+  /**
    * @returns {Map<string, string>} the connection properties (never null)
    */
   public getProperties(): Map< string, string > {
@@ -125,6 +133,13 @@ export class Connection implements Identifiable< string > {
    */
   public setJndiName( jndiName?: string ): void {
     this.dv__jndiName = jndiName ? jndiName : null;
+  }
+
+  /**
+   * @param {boolean} jdbc the jdbc state
+   */
+  public setJdbc( jdbc: boolean ): void {
+    this.dv__type = jdbc;
   }
 
   /**

--- a/src/main/ngapp/src/app/connections/shared/connection.service.ts
+++ b/src/main/ngapp/src/app/connections/shared/connection.service.ts
@@ -19,9 +19,12 @@ import { Injectable } from "@angular/core";
 import { Http } from "@angular/http";
 import { Connection } from "@connections/shared/connection.model";
 import { ConnectionsConstants } from "@connections/shared/connections-constants";
+import { JdbcTableFilter } from "@connections/shared/jdbc-table-filter.model";
 import { NewConnection } from "@connections/shared/new-connection.model";
+import { SchemaInfo } from "@connections/shared/schema-info.model";
 import { TemplateDefinition } from "@connections/shared/template-definition.model";
 import { ApiService } from "@core/api.service";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { environment } from "@environments/environment";
 import { PropertyDefinition } from "@shared/property-form/property-definition.model";
@@ -32,8 +35,8 @@ export class ConnectionService extends ApiService {
 
   private http: Http;
 
-  constructor( http: Http, logger: LoggerService ) {
-    super( logger  );
+  constructor( http: Http, appSettings: AppSettingsService, logger: LoggerService ) {
+    super( appSettings, logger  );
     this.http = http;
   }
 
@@ -83,7 +86,7 @@ export class ConnectionService extends ApiService {
 
   /**
    * Get the connection templates from the komodo rest interface
-   * @returns {Observable<Array<TemplateDefinition<any>>>}
+   * @returns {Observable<TemplateDefinition[]>}
    */
   public getConnectionTemplates(): Observable<TemplateDefinition[]> {
     return this.http
@@ -106,6 +109,46 @@ export class ConnectionService extends ApiService {
       .map((response) => {
         const entries = response.json() as Array<PropertyDefinition<any>>;
         return entries.map((entry) => PropertyDefinition.create( entry ));
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Get the schema infos for a Jdbc Connection
+   * @param {string} connectionId
+   * @returns {Observable<SchemaInfo[]>}
+   */
+  public getConnectionSchemaInfos(connectionId: string): Observable<SchemaInfo[]> {
+    return this.http
+      .get( environment.komodoTeiidUrl + "/connections/" + connectionId + "/JdbcCatalogSchema", this.getAuthRequestOptions())
+      .map((response) => {
+        const infos = response.json();
+        return infos.map((info) => SchemaInfo.create( info ));
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Get the tables for the specified input (connection and filters) for a Jdbc Connection
+   * @param {JdbcTableFilter} tableFilter
+   * @returns {Observable<string>}
+   */
+  public getJdbcConnectionTables(tableFilter: JdbcTableFilter): Observable<string[]> {
+    return this.http
+      .post( environment.komodoTeiidUrl + "/connections/Tables", tableFilter, this.getAuthRequestOptions())
+      .map((response) => {
+        const info = response.json();
+        const tableNames = [];
+        let i = 1;
+        let tableKey = "Table" + i;
+        let tableName = info.Information[tableKey];
+        while ( tableName && tableName.length > 0 ) {
+          tableNames.push(tableName);
+          i++;
+          tableKey = "Table" + i;
+          tableName = info.Information[tableKey];
+        }
+        return tableNames;
       })
       .catch( ( error ) => this.handleError( error ) );
   }

--- a/src/main/ngapp/src/app/connections/shared/jdbc-table-filter.model.ts
+++ b/src/main/ngapp/src/app/connections/shared/jdbc-table-filter.model.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The JDBC table filter model.
+ */
+export class JdbcTableFilter {
+  private dataSourceName: string;
+  private catalogFilter = "%";
+  private schemaFilter = "%";
+  private tableFilter = "%";
+
+  /**
+   * @param {Object} json the JSON representation of a JdbcTableFilter
+   * @returns {JdbcTableFilter} the new JdbcTableFilter (never null)
+   */
+  public static create( json: object = {} ): JdbcTableFilter {
+    const template = new JdbcTableFilter();
+    template.setValues( json );
+    return template;
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the connection name
+   */
+  public getConnectionName(): string {
+    return this.dataSourceName;
+  }
+
+  /**
+   * @returns {string} the catalog filter
+   */
+  public getCatalogFilter(): string {
+    return this.catalogFilter;
+  }
+
+  /**
+   * @returns {string} the schema filter
+   */
+  public getSchemaFilter(): string {
+    return this.schemaFilter;
+  }
+
+  /**
+   * @returns {string} the table filter
+   */
+  public getTableFilter(): string {
+    return this.tableFilter;
+  }
+
+  /**
+   * @param {string} name the connection name
+   */
+  public setConnectionName( name: string ): void {
+    this.dataSourceName = name;
+  }
+
+  /**
+   * @param {string} filter the catalog filter
+   */
+  public setCatalogFilter( filter?: string ): void {
+    this.catalogFilter = filter ? filter : "%";
+  }
+
+  /**
+   * @param {string} filter the schema filter
+   */
+  public setSchemaFilter( filter?: string ): void {
+    this.schemaFilter = filter ? filter : "%";
+  }
+
+  /**
+   * @param {string} filter the table filter
+   */
+  public setTableFilter( filter?: string ): void {
+    this.tableFilter = filter ? filter : "%";
+  }
+
+  /**
+   * Set all object values using the supplied Template json
+   * @param {Object} values
+   */
+  public setValues(values: object = {}): void {
+    Object.assign(this, values);
+  }
+
+}

--- a/src/main/ngapp/src/app/connections/shared/mock-connection.service.ts
+++ b/src/main/ngapp/src/app/connections/shared/mock-connection.service.ts
@@ -1,9 +1,27 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Injectable } from "@angular/core";
 import { Http } from "@angular/http";
 import { Connection } from "@connections/shared/connection.model";
 import { ConnectionService } from "@connections/shared/connection.service";
 import { NewConnection } from "@connections/shared/new-connection.model";
 import { TemplateDefinition } from "@connections/shared/template-definition.model";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import "rxjs/add/observable/of";
 import "rxjs/add/observable/throw";
@@ -24,8 +42,8 @@ export class MockConnectionService extends ConnectionService {
   private templ3 = new TemplateDefinition();
   private templs: TemplateDefinition[] = [this.templ1, this.templ2, this.templ3];
 
-  constructor( http: Http, logger: LoggerService ) {
-    super(http, logger);
+  constructor( http: Http, appSettings: AppSettingsService, logger: LoggerService ) {
+    super(http, appSettings, logger);
     this.conn1.setId("conn1");
     this.conn2.setId("conn2");
     this.conn3.setId("conn3");

--- a/src/main/ngapp/src/app/connections/shared/new-connection.model.ts
+++ b/src/main/ngapp/src/app/connections/shared/new-connection.model.ts
@@ -87,10 +87,10 @@ export class NewConnection {
   }
 
   /**
-   * @param {boolean} isJdbc the jdbc status (optional)
+   * @param {boolean} isJdbc the jdbc state
    */
-  public setJdbc( isJdbc?: boolean ): void {
-    this.jdbc = isJdbc ? isJdbc : true;
+  public setJdbc( isJdbc ): void {
+    this.jdbc = isJdbc;
   }
 
   /**

--- a/src/main/ngapp/src/app/connections/shared/schema-info.model.ts
+++ b/src/main/ngapp/src/app/connections/shared/schema-info.model.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * SchemaInfo model - returned from the komodo rest call.  The type of info will be
+ * 'Catalog' or 'Schema'.
+ */
+export class SchemaInfo {
+  private name: string;
+  private type: string;
+  private schemaNames: string[];
+
+  /**
+   * @param {Object} json the JSON representation of a Template
+   * @returns {TemplateDefinition} the new TemplateDefinition (never null)
+   */
+  public static create( json: object = {} ): SchemaInfo {
+    const template = new SchemaInfo();
+    template.setValues( json );
+    return template;
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the info name
+   */
+  public getName(): string {
+    return this.name;
+  }
+
+  /**
+   * @returns {string} the info type
+   */
+  public getType(): string {
+    return this.type;
+  }
+
+  /**
+   * @returns {string[]} the array of schema Names
+   */
+  public getSchemaNames(): string[] {
+    return this.schemaNames;
+  }
+
+  /**
+   * @param {string} name the info name
+   */
+  public setId( name?: string ): void {
+    this.name = name ? name : null;
+  }
+
+  /**
+   * @param {string} type the info type
+   */
+  public setType( type?: string ): void {
+    this.type = type ? type : null;
+  }
+
+  /**
+   * @param {string[]} schemaNames the array of schema names
+   */
+  public setSchemaNames( schemaNames?: string[] ): void {
+    this.schemaNames = schemaNames ? schemaNames : null;
+  }
+
+  /**
+   * Set all object values using the supplied Template json
+   * @param {Object} values
+   */
+  public setValues(values: object = {}): void {
+    Object.assign(this, values);
+  }
+
+}

--- a/src/main/ngapp/src/app/core/api.service.spec.ts
+++ b/src/main/ngapp/src/app/core/api.service.spec.ts
@@ -1,13 +1,14 @@
 import { inject, TestBed } from "@angular/core/testing";
 import { HttpModule } from "@angular/http";
 import { ApiService } from "@core/api.service";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 
 describe("ApiService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpModule],
-      providers: [LoggerService]
+      providers: [AppSettingsService, LoggerService]
     });
   });
 
@@ -19,8 +20,8 @@ describe("ApiService", () => {
 
 class MockService extends ApiService {
 
-  constructor( logger: LoggerService ) {
-    super( logger );
+  constructor( appSettings: AppSettingsService, logger: LoggerService ) {
+    super( appSettings, logger );
   }
 
 }

--- a/src/main/ngapp/src/app/core/api.service.ts
+++ b/src/main/ngapp/src/app/core/api.service.ts
@@ -16,6 +16,7 @@
  */
 
 import { Headers, RequestOptions, Response } from "@angular/http";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import "rxjs/add/observable/throw";
 import "rxjs/add/operator/catch";
@@ -25,9 +26,11 @@ import { ErrorObservable } from "rxjs/observable/ErrorObservable";
 
 export abstract class ApiService {
 
+  protected appSettings: AppSettingsService;
   protected logger: LoggerService;
 
-  constructor( logger: LoggerService ) {
+  constructor( appSettings: AppSettingsService, logger: LoggerService ) {
+    this.appSettings = appSettings;
     this.logger = logger;
   }
 
@@ -37,8 +40,17 @@ export abstract class ApiService {
    * @returns {RequestOptions}
    */
   protected getAuthRequestOptions(): RequestOptions {
-    const headers = new Headers({ "Authorization": "Basic " +  btoa("dsbUser:1demo-user1") });
+    const userPasswordStr = this.appSettings.getKomodoUser() + ":" + this.appSettings.getKomodoUserPassword();
+    const headers = new Headers({ "Authorization": "Basic " +  btoa(userPasswordStr) });
     return new RequestOptions({ headers });
+  }
+
+  /**
+   * Get the current user workspace path
+   * @returns {string} the current user workspace path
+   */
+  protected getKomodoUserWorkspacePath(): string {
+    return this.appSettings.getKomodoUserWorkspacePath();
   }
 
   protected handleError(error: Response): ErrorObservable {

--- a/src/main/ngapp/src/app/core/app-settings.service.spec.ts
+++ b/src/main/ngapp/src/app/core/app-settings.service.spec.ts
@@ -1,0 +1,15 @@
+import { inject, TestBed } from "@angular/core/testing";
+
+import { AppSettingsService } from "./app-settings.service";
+
+describe("AppSettingsService", () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AppSettingsService]
+    });
+  });
+
+  it("should be created", inject([AppSettingsService], (service: AppSettingsService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/main/ngapp/src/app/core/app-settings.service.ts
+++ b/src/main/ngapp/src/app/core/app-settings.service.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from "@angular/core";
+
+@Injectable()
+export class AppSettingsService {
+
+  private readonly komodoRoot = "tko:komodo/tko:workspace";
+
+  // TODO: temporary location for user and password
+  private readonly komodoUser = "dsbUser";
+  private readonly komodoUserPassword = "1demo-user1";
+
+  constructor() {
+    // Nothing to do
+  }
+
+  /*
+   * Get the komodo workspace path for the current user
+   * @returns {string} the komodo workspace path
+   */
+  public getKomodoUserWorkspacePath( ): string {
+    return this.komodoRoot + "/" + this.komodoUser;
+  }
+
+  /*
+   * Get the logged in komodo user
+   * @returns {string} the komodo user
+   */
+  public getKomodoUser( ): string {
+    return this.komodoUser;
+  }
+
+  /*
+   * Get the logged in komodo user password
+   * @returns {string} the komodo user password
+   */
+  public getKomodoUserPassword( ): string {
+    return this.komodoUserPassword;
+  }
+
+}

--- a/src/main/ngapp/src/app/core/core.module.ts
+++ b/src/main/ngapp/src/app/core/core.module.ts
@@ -19,6 +19,7 @@ import { CommonModule } from "@angular/common";
 import { NgModule, Optional, SkipSelf } from "@angular/core";
 import { HttpModule } from "@angular/http";
 import { RouterModule } from "@angular/router";
+import { AppSettingsService } from "@core/app-settings.service";
 import { BreadcrumbComponent } from "@core/breadcrumbs/breadcrumb/breadcrumb.component";
 import { BreadcrumbsComponent } from "@core/breadcrumbs/breadcrumbs.component";
 import { LoggerService } from "@core/logger.service";
@@ -44,6 +45,7 @@ import { VerticalNavComponent } from "@core/vertical-nav/vertical-nav.component"
     VerticalNavComponent
   ],
   providers: [
+    AppSettingsService,
     LoggerService
   ]
 })

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
@@ -3,29 +3,12 @@
              (onCancel)="cancelClicked($event)"
              (onNext)="nextClicked($event)"
              (onStepChange)="stepChanged($event)">
-  <!-- ------------------------- -->
-  <!-- Step 1 : Basic Properties -->
-  <!-- ------------------------- -->
+  <!-- ----------------------------- -->
+  <!-- Step 1 : Name and Description -->
+  <!-- ----------------------------- -->
   <pfng-wizard-step [config]="step1Config">
-    <div *ngIf="connectionsLoading">
-      <div class="spinner spinner-lg blank-slate-pf-icon"></div>
-    </div>
-    <!-- Connections failed to load -->
-    <div class="card-pf card-pf-accented card-pf-error" *ngIf="!connectionsLoading && !connectionsLoadSuccess">
-      <div class="card-pf-heading">
-        <h2 class="card-pf-title">
-          <span class="fa fa-fw fa-exclamation"></span>
-          <span i18n="@@addDataserviceWizard.stepInitError">Step Initialization Error</span>
-        </h2>
-      </div>
-      <div class="card-pf-body">
-        <p  i18n="@@addDataserviceWizard.couldNotLoadConnections">
-          Could not load the connections.  Please Try relaunching the wizard or check the console log.
-        </p>
-      </div>
-    </div>
-    <h3 *ngIf="!connectionsLoading && connectionsLoadSuccess"><i>{{ step1InstructionMessage }}</i></h3>
-    <form [formGroup]=basicPropertyForm class="form-horizontal" *ngIf="!connectionsLoading && connectionsLoadSuccess">
+    <h3><i>{{ step1InstructionMessage }}</i></h3>
+    <form [formGroup]=basicPropertyForm class="form-horizontal">
       <div [ngClass]="nameValid ? 'form-group' : 'form-group has-error'">
         <label class="col-sm-2 control-label">Name</label>
         <div class="col-sm-5">
@@ -33,39 +16,44 @@
           <div class="help-block" *ngIf="!nameValid">{{ getBasicPropertyErrorMessage("name") }}</div>
         </div>
       </div>
-      <div [ngClass]="connectionValid ? 'form-group' : 'form-group has-error'">
-        <label class="col-sm-2 control-label">Connection</label>
+      <div [ngClass]="'form-group'">
+        <label class="col-sm-2 control-label">Description</label>
         <div class="col-sm-5">
-          <select class="form-control" formControlName="connection" title="">
-            <option value="" selected hidden>-- Select a Connection ---</option>
-            <option *ngFor="let connection of connectionNames" [value]="connection">{{ connection }}</option>
-          </select>
-          <div class="help-block" *ngIf="!connectionValid">{{ getBasicPropertyErrorMessage("connection") }}</div>
+          <input class="form-control" formControlName="description" title="">
         </div>
       </div>
     </form>
   </pfng-wizard-step>
-  <!-- -------------------------- -->
-  <!-- Step 2 : Review and Create -->
-  <!-- -------------------------- -->
+  <!-- ------------------------- -->
+  <!-- Step 2 : Table Selection -->
+  <!-- ------------------------- -->
   <pfng-wizard-step [config]="step2Config">
-    <!-- Step 2A: Review -->
-    <pfng-wizard-substep [config]="step2aConfig">
-      <h3><i>{{ step2InstructionMessage }}</i></h3>
+    <h3><i>{{ step2InstructionMessage }}</i></h3>
+    <app-connection-table-selector (tableSelectionChanged)="updatePage2ValidStatus()"></app-connection-table-selector>
+  </pfng-wizard-step>
+  <!-- -------------------------- -->
+  <!-- Step 3 : Review and Create -->
+  <!-- -------------------------- -->
+  <pfng-wizard-step [config]="step3Config">
+    <!-- Step 3A: Review -->
+    <pfng-wizard-substep [config]="step3aConfig">
+      <h3><i>{{ step3InstructionMessage }}</i></h3>
       <h4>Dataservice Properties:</h4>
       <form class="form-horizontal">
         <div class="form-group">
           <label class="col-sm-2 control-label">Name:</label>
           <label class="col-sm-10">{{ dataserviceName }}</label>
         </div>
+        <!--
         <div class="form-group">
           <label class="col-sm-2 control-label">Connection:</label>
           <label class="col-sm-5">{{ connectionName }}</label>
         </div>
+        -->
       </form>
     </pfng-wizard-substep>
-    <!-- Step 2B: Create -->
-    <pfng-wizard-substep [config]="step2bConfig" (onShow)="createDataservice()">
+    <!-- Step 3B: Create -->
+    <pfng-wizard-substep [config]="step3bConfig" (onShow)="createDataservice()">
       <div class="wizard-pf-contents">
         <!-- In progress -->
         <div class="wizard-pf-process blank-slate-pf" *ngIf="!createComplete">

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.spec.ts
@@ -5,8 +5,12 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { ConnectionService } from "@connections/shared/connection.service";
 import { MockConnectionService } from "@connections/shared/mock-connection.service";
 import { CoreModule } from "@core/core.module";
+import { ConnectionTableSelectorComponent } from "@dataservices/connection-table-selector/connection-table-selector.component";
+import { JdbcTableSelectorComponent } from "@dataservices/jdbc-table-selector/jdbc-table-selector.component";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { PropertyFormPropertyComponent } from "@shared/property-form/property-form-property/property-form-property.component";
 import { PropertyFormComponent } from "@shared/property-form/property-form.component";
 import { PatternFlyNgModule } from "patternfly-ng";
@@ -19,10 +23,12 @@ describe("AddDataserviceWizardComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [ CoreModule, FormsModule, PatternFlyNgModule, ReactiveFormsModule, RouterTestingModule ],
-      declarations: [ AddDataserviceWizardComponent, PropertyFormComponent, PropertyFormPropertyComponent ],
+      declarations: [ AddDataserviceWizardComponent, ConnectionTableSelectorComponent, JdbcTableSelectorComponent,
+                      PropertyFormComponent, PropertyFormPropertyComponent ],
       providers: [
         { provide: DataserviceService, useClass: MockDataserviceService },
         { provide: ConnectionService, useClass: MockConnectionService },
+        { provide: VdbService, useClass: MockVdbService },
       ]
     })
     .compileComponents().then(() => {

--- a/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.spec.ts
@@ -6,8 +6,12 @@ import { ConnectionService } from "@connections/shared/connection.service";
 import { MockConnectionService } from "@connections/shared/mock-connection.service";
 import { CoreModule } from "@core/core.module";
 import { AddDataserviceWizardComponent } from "@dataservices/add-dataservice-wizard/add-dataservice-wizard.component";
+import { ConnectionTableSelectorComponent } from "@dataservices/connection-table-selector/connection-table-selector.component";
+import { JdbcTableSelectorComponent } from "@dataservices/jdbc-table-selector/jdbc-table-selector.component";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
 import { PatternFlyNgModule } from "patternfly-ng";
 import { AddDataserviceComponent } from "./add-dataservice.component";
@@ -19,10 +23,12 @@ describe("AddDataserviceComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [ CoreModule, PatternFlyNgModule, FormsModule, ReactiveFormsModule, RouterTestingModule, SharedModule ],
-      declarations: [ AddDataserviceComponent, AddDataserviceWizardComponent ],
+      declarations: [ AddDataserviceComponent, AddDataserviceWizardComponent,
+                      ConnectionTableSelectorComponent, JdbcTableSelectorComponent ],
       providers: [
         { provide: DataserviceService, useClass: MockDataserviceService },
-        { provide: ConnectionService, useClass: MockConnectionService }
+        { provide: ConnectionService, useClass: MockConnectionService },
+        { provide: VdbService, useClass: MockVdbService }
       ]
     })
     .compileComponents().then(() => {

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.css
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.css
@@ -1,0 +1,20 @@
+.list-div {
+  position: relative;
+  height: 100%;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.connection-list .list-view-pf-main-info {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+}
+
+.connection-list .list-group-item-heading {
+  font-size: 12px;
+  margin-right: 5px;
+}
+
+.connection-list .list-view-pf-description {
+  width: 95%;
+}

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.html
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.html
@@ -1,0 +1,54 @@
+<div>
+  <!-- ---------------- -->
+  <!-- Connections List -->
+  <!-- ---------------- -->
+  <div class="list-div col-sm-3">
+    <strong>Connections</strong>
+    <div *ngIf="connectionsLoading">
+      <span class="spinner spinner-sm spinner-inline"></span>
+    </div>
+    <div *ngIf="connectionsLoadedInvalid">
+      <div class="alert alert-info">
+        <span class="pficon pficon-info"></span>
+        <strong>Problem Loading Connections!</strong>
+      </div>
+    </div>
+    <div class="connection-list list-group list-view-pf" *ngIf="connectionsLoadedValid">
+      <div class="list-group-item list-view-pf-stacked" *ngFor="let connection of getAllConnections()" [class.active]="isConnectionSelected(connection)" (click)="toggleConnectionSelected(connection)">
+        <div class="list-view-pf-main-info">
+          <div class="list-view-pf-left">
+            <span class="fa fa-plug list-view-pf-icon-sm"></span>
+          </div>
+          <div class="list-view-pf-body">
+            <div class="list-view-pf-description">
+              <div class="list-group-item-heading">
+                {{ connection.getId() }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- ------------------------------------------- -->
+  <!-- Connection Content Area                     -->
+  <!-- 1) JDBC Connection selected                 -->
+  <!-- 2) Non-JDBC Connection selected             -->
+  <!-- 3) No Connection selected                   -->
+  <!-- ------------------------------------------- -->
+  <div class="col-sm-9">
+    <app-jdbc-table-selector [connection]="selectedConnection" (tableSelectionChanged)="onTableSelectionChanged()" *ngIf="hasJdbcConnectionSelected()"></app-jdbc-table-selector>
+  </div>
+  <div class="col-sm-9" *ngIf="hasNonJdbcConnectionSelected()">
+    <div class="alert alert-info">
+      <span class="pficon pficon-info"></span>
+      <strong>Non-JDBC Connections are not supported</strong>
+    </div>
+  </div>
+  <div class="col-sm-9" *ngIf="!hasSelectedConnection()">
+    <div class="alert alert-info">
+      <span class="pficon pficon-info"></span>
+      <strong>Please select a Connection</strong>
+    </div>
+  </div>
+</div>

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.spec.ts
@@ -1,0 +1,39 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { FormsModule } from "@angular/forms";
+import { HttpModule } from "@angular/http";
+import { ConnectionService } from "@connections/shared/connection.service";
+import { MockConnectionService } from "@connections/shared/mock-connection.service";
+import { AppSettingsService } from "@core/app-settings.service";
+import { LoggerService } from "@core/logger.service";
+import { JdbcTableSelectorComponent } from "@dataservices/jdbc-table-selector/jdbc-table-selector.component";
+import { ConnectionTableSelectorComponent } from "./connection-table-selector.component";
+
+describe("ConnectionTableSelectorComponent", () => {
+  let component: ConnectionTableSelectorComponent;
+  let fixture: ComponentFixture<ConnectionTableSelectorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ FormsModule, HttpModule ],
+      declarations: [ ConnectionTableSelectorComponent, JdbcTableSelectorComponent ],
+      providers: [
+        AppSettingsService, LoggerService,
+        { provide: ConnectionService, useClass: MockConnectionService },
+      ]
+    })
+      .compileComponents().then(() => {
+      // nothing to do
+    });
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConnectionTableSelectorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should be created", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.ts
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ViewChild } from "@angular/core";
+import { Output } from "@angular/core";
+import { EventEmitter } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
+import { Connection } from "@connections/shared/connection.model";
+import { ConnectionService } from "@connections/shared/connection.service";
+import { LoggerService } from "@core/logger.service";
+import { JdbcTableSelectorComponent } from "@dataservices/jdbc-table-selector/jdbc-table-selector.component";
+import { Table } from "@dataservices/shared/table.model";
+import { LoadingState } from "@shared/loading-state.enum";
+
+@Component({
+  selector: "app-connection-table-selector",
+  templateUrl: "./connection-table-selector.component.html",
+  styleUrls: ["./connection-table-selector.component.css"]
+})
+export class ConnectionTableSelectorComponent implements OnInit {
+
+  @Output() public tableSelectionChanged: EventEmitter<void> = new EventEmitter<void>();
+
+  @ViewChild(JdbcTableSelectorComponent) public jdbcTableSelector: JdbcTableSelectorComponent;
+
+  private connectionService: ConnectionService;
+  private allConnections: Connection[] = [];
+  private selectedConn: Connection;
+  private connectionLoadingState: LoadingState = LoadingState.LOADING;
+  private logger: LoggerService;
+
+  constructor( connectionService: ConnectionService, logger: LoggerService ) {
+    this.connectionService = connectionService;
+    this.logger = logger;
+  }
+
+  /*
+   * Component initialization
+   */
+  public ngOnInit(): void {
+    // Load the connections
+    this.connectionLoadingState = LoadingState.LOADING;
+    const self = this;
+    this.connectionService
+      .getAllConnections()
+      .subscribe(
+        (conns) => {
+          self.allConnections = conns;
+          self.connectionLoadingState = LoadingState.LOADED_VALID;
+        },
+        (error) => {
+          self.logger.error("[ConnectionTableSelectorComponent] Error getting connections: %o", error);
+          self.connectionLoadingState = LoadingState.LOADED_INVALID;
+        }
+      );
+  }
+
+  /**
+   * Toggles the selection
+   * @param {Connection} connection the connection whose selection changed
+   */
+  public toggleConnectionSelected(connection: Connection): void {
+    // Connection currently selected, so deselect it
+    if (this.isConnectionSelected(connection)) {
+      this.selectedConn = null;
+    } else {
+      // Connection not currently selected or nothing selected, so select it.
+      this.selectedConn = connection;
+    }
+    // Set the specific selector with the current connection
+    if (this.jdbcTableSelector) {
+      if (this.selectedConn && this.selectedConn.isJdbc()) {
+        this.jdbcTableSelector.setConnection(connection);
+      } else {
+        this.jdbcTableSelector.setConnection(null);
+      }
+    }
+  }
+
+  /**
+   * Respond to child table selection changes by propagating up my parent
+   */
+  public onTableSelectionChanged( ): void {
+    this.tableSelectionChanged.emit();
+  }
+
+  /**
+   * selector is valid if at least one table is selected.
+   * @returns {boolean} the selector status (true if one or more tables selected)
+   */
+  public valid( ): boolean {
+    return this.getSelectedTables().length > 0;
+  }
+
+  /**
+   * Determine if connections are loading
+   */
+  public get connectionsLoading( ): boolean {
+    return this.connectionLoadingState === LoadingState.LOADING;
+  }
+
+  /**
+   * Determine if connections are loaded and valid
+   */
+  public get connectionsLoadedValid( ): boolean {
+    return this.connectionLoadingState === LoadingState.LOADED_VALID;
+  }
+
+  /**
+   * Determine if connections are loaded and invalid
+   */
+  public get connectionsLoadedInvalid( ): boolean {
+    return this.connectionLoadingState === LoadingState.LOADED_INVALID;
+  }
+
+  /**
+   * Determine if the supplied connection is currently selected.
+   * @param {Connection} connection the connection
+   * @returns {boolean} true if the connection is selected
+   */
+  public isConnectionSelected(connection: Connection): boolean {
+    return this.selectedConn && this.selectedConn === connection;
+  }
+
+  /**
+   * Determine if a JDBC connection is currently selected
+   * @returns {boolean} true if a JDBC connection is selected
+   */
+  public hasJdbcConnectionSelected(): boolean {
+    return (this.selectedConn && this.selectedConn.isJdbc());
+  }
+
+  /**
+   * Determine if a non-JDBC connection is currently selected
+   * @returns {boolean} true if a non-JDBC connection is selected
+   */
+  public hasNonJdbcConnectionSelected(): boolean {
+    return (this.selectedConn && !this.selectedConn.isJdbc());
+  }
+
+  /**
+   * Determine if anything is selected
+   * @returns {boolean} true if a connection is selected
+   */
+  public hasSelectedConnection( ): boolean {
+    return this.selectedConn !== null;
+  }
+
+  /**
+   * Get the currently selected Connection
+   * @returns {Connection} the current selection (may be null)
+   */
+  public get selectedConnection( ): Connection {
+    return this.selectedConn;
+  }
+
+  /**
+   * Set the currently selected Connection
+   * @param {Connection} conn the current selection (may be null)
+   */
+  public set selectedConnection(conn: Connection) {
+    this.selectedConn = conn;
+  }
+
+  /*
+   * Return all available Connections
+   * @returns {Connection[]} the list of all Connections
+   */
+  public getAllConnections(): Connection[] {
+    return this.allConnections;
+  }
+
+  /*
+   * Return all currently selected Tables
+   * @returns {Table[]} the list of selected Tables
+   */
+  public getSelectedTables(): Table[] {
+    const selectedTables = [];
+    if (this.jdbcTableSelector) {
+      return this.jdbcTableSelector.getSelectedTables();
+    }
+    return selectedTables;
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
@@ -9,11 +9,16 @@
             <span class="fa fa-fw fa-table dataservice-card-icon"></span>
             <span><a [routerLink]="[dataservice.getId()]">{{ dataservice.getId() }}</a></span>
             <span class="pull-right fa fa-fw fa-close dataservice-card-action-icon" style="color:darkred;" (click)="onDeleteDataservice(dataservice.getId())"></span>
+            <span class="pull-right fa fa-fw fa-arrow-up dataservice-card-action-icon" (click)="onPublishDataservice(dataservice.getId())"></span>
+            <span class="pull-right fa fa-fw fa-play dataservice-card-action-icon" style="color:darkgreen;" (click)="onTestDataservice(dataservice.getId())"></span>
           </h2>
           <hr/>
+          <div>
+            <span>{{ dataservice.getDescription() }}</span>
+          </div>
           <!--
           <div>
-            <span><b i18n="@@dataservicesCards.Connection" >Connection:</b>&nbsp;&nbsp;{{ dataservice.getConnection() }}</span>
+            <span><b i18n="@@dataservicesCards.Connection" >Connection:</b>&nbsp;&nbsp;{{ dataservice.getConnection().getName() }}</span>
           </div>
           <div class="dataservice-tags" *ngIf="dataservice.tags && dataservice.tags.length > 0">
             <span class="dataservice-tags-label">Tags:</span>

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
@@ -31,6 +31,8 @@ export class DataservicesCardsComponent {
   @Output() public dataserviceSelected: EventEmitter<Dataservice> = new EventEmitter<Dataservice>();
   @Output() public dataserviceDeselected: EventEmitter<Dataservice> = new EventEmitter<Dataservice>();
   @Output() public tagSelected: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public testDataservice: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public publishDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteDataservice: EventEmitter<string> = new EventEmitter<string>();
 
   /**
@@ -50,6 +52,14 @@ export class DataservicesCardsComponent {
 
   public isSelected(dataservice: Dataservice): boolean {
     return this.selectedDataservices.indexOf(dataservice) !== -1;
+  }
+
+  public onTestDataservice(dataserviceName: string): void {
+    this.testDataservice.emit(dataserviceName);
+  }
+
+  public onPublishDataservice(dataserviceName: string): void {
+    this.publishDataservice.emit(dataserviceName);
   }
 
   public onDeleteDataservice(dataserviceName: string): void {

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
@@ -14,10 +14,10 @@
           -->
         </div>
         <div class="list-view-pf-additional-info">
-          <!--
           <div>
-            <span><b i18n="@@dataservicesList.Connection" >Connection:</b>&nbsp&nbsp;&nbsp;{{ dataservice.getConnection() }}&nbsp;&nbsp;&nbsp;&nbsp;</span>
+            <span>{{ dataservice.getDescription() }}</span>
           </div>
+          <!--
           <div class="dataservice-tags" *ngIf="dataservice.tags && dataservice.tags.length > 0">
             <span class="dataservice-tags-label">Tags:</span>
             <span class="dataservice-tag" *ngFor="let tag of dataservice.tags" (click)="selectTag(tag, $event)">{{ tag }}</span>
@@ -26,6 +26,8 @@
         </div>
       </div>
       <div class="list-view-pf-actions">
+        <button i18n="@@dataservicesList.test" class="btn btn-default" type="button" (click)="onTestDataservice(dataservice.getId())">Test</button>
+        <button i18n="@@dataservicesList.publish" class="btn btn-default" type="button" (click)="onPublishDataservice(dataservice.getId())">Publish</button>
         <button i18n="@@dataservicesList.delete" class="btn btn-danger" type="button" (click)="onDeleteDataservice(dataservice.getId())">Delete</button>
       </div>
     </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
@@ -32,6 +32,8 @@ export class DataservicesListComponent {
   @Output() public dataserviceSelected: EventEmitter<Dataservice> = new EventEmitter<Dataservice>();
   @Output() public dataserviceDeselected: EventEmitter<Dataservice> = new EventEmitter<Dataservice>();
   @Output() public tagSelected: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public testDataservice: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public publishDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteDataservice: EventEmitter<string> = new EventEmitter<string>();
 
   private router: Router;
@@ -55,14 +57,22 @@ export class DataservicesListComponent {
     return this.selectedDataservices.indexOf(dataservice) !== -1;
   }
 
+  public onTestDataservice(dataserviceName: string): void {
+    this.testDataservice.emit(dataserviceName);
+  }
+
+  public onPublishDataservice(dataserviceName: string): void {
+    this.publishDataservice.emit(dataserviceName);
+  }
+
   public onDeleteDataservice(dataserviceName: string): void {
     this.deleteDataservice.emit(dataserviceName);
   }
 
-  public onSelectTag(tag: string, event: MouseEvent): void {
-    event.stopPropagation();
-    event.preventDefault();
-    this.tagSelected.emit(tag);
-  }
+  // public onSelectTag(tag: string, event: MouseEvent): void {
+  //   event.stopPropagation();
+  //   event.preventDefault();
+  //   this.tagSelected.emit(tag);
+  // }
 
 }

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -90,11 +90,11 @@
       <!-- The list or card view -->
       <div class="col-md-12" *ngIf="isLoaded('dataservices')">
         <app-dataservices-list *ngIf="isListLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
-                              (deleteDataservice)="onDelete($event)"
-                              (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-list>
+                               (testDataservice)="onTest($event)" (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
+                               (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-list>
         <app-dataservices-cards *ngIf="isCardLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
-                               (deleteDataservice)="onDelete($event)"
-                               (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-cards>
+                                (testDataservice)="onTest($event)" (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
+                                (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-cards>
       </div>
 
     </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
@@ -9,6 +9,8 @@ import { DataservicesListComponent } from "@dataservices/dataservices-list/datas
 import { DataservicesComponent } from "@dataservices/dataservices.component";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
 import { ModalModule } from "ngx-bootstrap";
 
@@ -19,7 +21,10 @@ describe("DataservicesComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [ CoreModule, FormsModule, HttpModule, ModalModule.forRoot(), RouterTestingModule, SharedModule ],
-      declarations: [ DataservicesComponent, DataservicesListComponent, DataservicesCardsComponent ]
+      declarations: [ DataservicesComponent, DataservicesListComponent, DataservicesCardsComponent ],
+      providers: [
+        { provide: VdbService, useClass: MockVdbService },
+      ]
     });
 
     // use mock service

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.ts
@@ -133,6 +133,14 @@ export class DataservicesComponent extends AbstractPageComponent {
     // this.selectedServices.splice(this.selectedServices.indexOf(dataservice), 1);
   }
 
+  public onTest(svcName: string): void {
+    alert("Test Dataservice " + svcName);
+  }
+
+  public onPublish(svcName: string): void {
+    alert("Publish Dataservice " + svcName);
+  }
+
   public onDelete(svcName: string): void {
     this.dataserviceNameForDelete = svcName;
     this.confirmDeleteDialog.open();

--- a/src/main/ngapp/src/app/dataservices/dataservices.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.module.ts
@@ -26,10 +26,13 @@ import { DataservicesListComponent } from "@dataservices/dataservices-list/datas
 import { DataservicesRoutingModule } from "@dataservices/dataservices-routing.module";
 import { DataservicesComponent } from "@dataservices/dataservices.component";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
 import { PatternFlyNgModule } from "patternfly-ng";
 import { AddDataserviceWizardComponent } from "./add-dataservice-wizard/add-dataservice-wizard.component";
 import { AddDataserviceComponent } from "./add-dataservice/add-dataservice.component";
+import { ConnectionTableSelectorComponent } from "./connection-table-selector/connection-table-selector.component";
+import { JdbcTableSelectorComponent } from "./jdbc-table-selector/jdbc-table-selector.component";
 
 @NgModule({
   imports: [
@@ -47,10 +50,13 @@ import { AddDataserviceComponent } from "./add-dataservice/add-dataservice.compo
     DataservicesComponent,
     DataservicesListComponent,
     AddDataserviceWizardComponent,
-    AddDataserviceComponent
+    AddDataserviceComponent,
+    ConnectionTableSelectorComponent,
+    JdbcTableSelectorComponent
   ],
   providers: [
     DataserviceService,
+    VdbService,
     LoggerService
   ],
   exports: [

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.css
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.css
@@ -1,0 +1,28 @@
+.list-div {
+  position: relative;
+  height: 100%;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.jdbc-list .list-view-pf-main-info {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+}
+
+.jdbc-list .list-view-pf-checkbox {
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-top: 0;
+  margin-right: 5px;
+  margin-bottom: 0;
+}
+
+.jdbc-list .list-group-item-heading {
+  font-size: 12px;
+  margin-right: 5px;
+}
+
+.jdbc-list .list-view-pf-description {
+  width: 95%;
+}

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.html
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.html
@@ -1,0 +1,105 @@
+<!-- ------------- -->
+<!-- Column Titles -->
+<!-- ------------- -->
+<div class="col-sm-4">
+  <strong>Schemas</strong>
+</div>
+<div class="col-sm-4">
+  <strong>Tables</strong>
+</div>
+<div class="col-sm-4">
+  <strong>Selections</strong>
+</div>
+<!-- ------------- -->
+<!-- Schemas List  -->
+<!-- ------------- -->
+<div class="col-sm-4" *ngIf="schemasLoading">
+  <span class="spinner spinner-sm spinner-inline"></span>
+</div>
+<div class="col-sm-4" *ngIf="schemasLoadedInvalid">
+  <div class="alert alert-info">
+    <span class="pficon pficon-info"></span>
+    <strong>Unable to load schema</strong>
+  </div>
+</div>
+<div class="col-sm-4" *ngIf="schemasLoadedValidEmpty">
+  <div class="alert alert-info">
+    <span class="pficon pficon-info"></span>
+    <strong>No schema available</strong>
+  </div>
+</div>
+<div class="list-div col-sm-4" *ngIf="schemasLoadedValidNotEmpty">
+  <div class="jdbc-list list-group list-view-pf">
+    <div class="list-group-item list-view-pf-stacked" *ngFor="let schema of getSchemas()" [class.active]="isSchemaSelected(schema)" (click)="toggleSchemaSelected(schema)">
+      <div class="list-view-pf-main-info">
+        <div class="list-view-pf-body">
+          <div class="list-view-pf-description">
+            <div class="list-group-item-heading">
+              {{ schema.getDisplayName() }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- ------------- -->
+<!--  Tables List  -->
+<!-- ------------- -->
+<div class="col-sm-4" *ngIf="hasSelectedSchema && tablesLoading">
+  <span class="spinner spinner-sm spinner-inline"></span>
+</div>
+<div class="col-sm-4" *ngIf="hasSelectedSchema && tablesLoadedInvalid">
+  <div class="alert alert-info">
+    <span class="pficon pficon-info"></span>
+    <strong>Unable to load tables</strong>
+  </div>
+</div>
+<div class="col-sm-4" *ngIf="hasSelectedSchema && tablesLoadedValidEmpty">
+  <div class="alert alert-info">
+    <span class="pficon pficon-info"></span>
+    <strong>No tables available</strong>
+  </div>
+</div>
+<div class = "list-div col-sm-4" *ngIf="hasSelectedSchema && tablesLoadedValidNotEmpty">
+  <div class="jdbc-list list-group list-view-pf">
+    <div class="list-group-item list-view-pf-stacked" *ngFor="let table of getTables()">
+      <div class="list-view-pf-checkbox">
+        <input type="checkbox" title="" [(ngModel)]="table.selected" (change)="selectedTablesChanged()">
+      </div>
+      <div class="list-view-pf-main-info">
+        <div class="list-view-pf-body">
+          <div class="list-view-pf-description">
+            <div class="list-group-item-heading">
+              {{ table.getName() }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- ----------------------- -->
+<!--  Table Selections List  -->
+<!-- ----------------------- -->
+<div class="col-sm-4" *ngIf="hasSelectedSchema && !hasSelectedTables()">
+  <div class="alert alert-info">
+    <span class="pficon pficon-info"></span>
+    <strong>No tables selected</strong>
+  </div>
+</div>
+<div class = "list-div col-sm-4" *ngIf="hasSelectedSchema && hasSelectedTables()">
+  <div class="jdbc-list list-group list-view-pf">
+    <div class="list-group-item list-view-pf-stacked" *ngFor="let table of getSelectedTables()">
+      <div class="list-view-pf-main-info">
+        <div class="list-view-pf-body">
+          <div class="list-view-pf-description">
+            <div class="list-group-item-heading">
+              {{ table.getName() }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.spec.ts
@@ -1,0 +1,38 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { FormsModule } from "@angular/forms";
+import { HttpModule } from "@angular/http";
+import { ConnectionService } from "@connections/shared/connection.service";
+import { MockConnectionService } from "@connections/shared/mock-connection.service";
+import { AppSettingsService } from "@core/app-settings.service";
+import { LoggerService } from "@core/logger.service";
+import { JdbcTableSelectorComponent } from "./jdbc-table-selector.component";
+
+describe("JdbcTableSelectorComponent", () => {
+  let component: JdbcTableSelectorComponent;
+  let fixture: ComponentFixture<JdbcTableSelectorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ FormsModule, HttpModule ],
+      declarations: [ JdbcTableSelectorComponent ],
+      providers: [
+        AppSettingsService, LoggerService,
+        { provide: ConnectionService, useClass: MockConnectionService },
+      ]
+    })
+      .compileComponents().then(() => {
+      // nothing to do
+    });
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(JdbcTableSelectorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should be created", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.ts
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.ts
@@ -1,0 +1,302 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnInit } from "@angular/core";
+import { EventEmitter } from "@angular/core";
+import { Output } from "@angular/core";
+import { Input } from "@angular/core";
+import { Connection } from "@connections/shared/connection.model";
+import { ConnectionService } from "@connections/shared/connection.service";
+import { JdbcTableFilter } from "@connections/shared/jdbc-table-filter.model";
+import { SchemaInfo } from "@connections/shared/schema-info.model";
+import { LoggerService } from "@core/logger.service";
+import { CatalogSchema } from "@dataservices/shared/catalog-schema.model";
+import { TableSelector } from "@dataservices/shared/table-selector";
+import { Table } from "@dataservices/shared/table.model";
+import { LoadingState } from "@shared/loading-state.enum";
+
+@Component({
+  selector: "app-jdbc-table-selector",
+  templateUrl: "./jdbc-table-selector.component.html",
+  styleUrls: ["./jdbc-table-selector.component.css"]
+})
+
+export class JdbcTableSelectorComponent implements OnInit, TableSelector {
+
+  @Input() public connection: Connection;
+  @Output() public tableSelectionChanged: EventEmitter<void> = new EventEmitter<void>();
+
+  private connectionService: ConnectionService;
+  private logger: LoggerService;
+  private schemas: CatalogSchema[] = [];
+  private tables: Table[] = [];
+  private selectedSchemas: CatalogSchema[] = [];
+  private schemaLoadingState: LoadingState = LoadingState.LOADING;
+  private tableLoadingState: LoadingState = LoadingState.LOADING;
+
+  constructor( connectionService: ConnectionService, logger: LoggerService ) {
+    this.connectionService = connectionService;
+    this.logger = logger;
+  }
+
+  public ngOnInit(): void {
+    // Load the schema info for a connection
+    this.setConnection(this.connection);
+  }
+
+  /*
+   * Set the connection for this jdbc table selector
+   * @param {Connection} conn the jdbc connection
+   */
+  public setConnection(conn: Connection): void {
+    if (conn && conn.isJdbc()) {
+      this.connection = conn;
+      // Load the schema info for a connection
+      this.schemas = [];
+      this.schemaLoadingState = LoadingState.LOADING;
+      const self = this;
+      this.connectionService
+        .getConnectionSchemaInfos(this.connection.getId())
+        .subscribe(
+          (infos) => {
+            self.generateSchemaNames(infos);
+            self.schemaLoadingState = LoadingState.LOADED_VALID;
+          },
+          (error) => {
+            self.logger.error("[JdbcTableSelectorComponent] Error getting schemas: %o", error);
+            self.schemaLoadingState = LoadingState.LOADED_INVALID;
+          }
+        );
+    } else {
+      this.schemas = [];
+      this.schemaLoadingState = LoadingState.LOADING;
+    }
+  }
+
+  /*
+   * Toggle the schema selection
+   * @param {CatalogSchema} schema the schema that has been selected or deselected
+   */
+  public toggleSchemaSelected(schema: CatalogSchema): void {
+    if (this.isSchemaSelected(schema)) {
+      this.selectedSchemas.shift();
+      // Deselection of schema clears tables
+      this.tables = [];
+      this.selectedTablesChanged();
+    } else {
+      // Only allow one item to be selected
+      this.selectedSchemas.shift();
+      this.selectedSchemas.push(schema);
+      const filterInfo = new JdbcTableFilter();
+      filterInfo.setConnectionName(this.connection.getId());
+      filterInfo.setCatalogFilter(schema.getCatalogName());
+      filterInfo.setSchemaFilter(schema.getName());
+      filterInfo.setTableFilter("%");
+      this.loadTablesForSchema(filterInfo);
+    }
+  }
+
+  /*
+   * Determines if the provided schema is selected
+   * @param {CatalogSchema} schema the CatalogSchema to check
+   */
+  public isSchemaSelected(schema: CatalogSchema): boolean {
+    return this.selectedSchemas.indexOf(schema) !== -1;
+  }
+
+  /*
+   * Returns the currently selected schema.
+   * @returns {CatalogSchema} the selected schema
+   */
+  public get selectedSchema( ): CatalogSchema {
+    return this.selectedSchemas[0];
+  }
+
+  /*
+   * Returns the currently selected schema.
+   * @returns {CatalogSchema} the selected schema
+   */
+  public get hasSelectedSchema( ): boolean {
+    return this.selectedSchemas.length > 0;
+  }
+
+  /**
+   * Determine if schemas are loading
+   */
+  public get schemasLoading( ): boolean {
+    return this.schemaLoadingState === LoadingState.LOADING;
+  }
+
+  /**
+   * Determine if schemas are loaded, valid and not empty
+   */
+  public get schemasLoadedValidNotEmpty( ): boolean {
+    return (this.schemaLoadingState === LoadingState.LOADED_VALID) && this.schemas.length > 0;
+  }
+
+  /**
+   * Determine if schemas are loaded, valid but empty
+   */
+  public get schemasLoadedValidEmpty( ): boolean {
+    return (this.schemaLoadingState === LoadingState.LOADED_VALID) && this.schemas.length === 0;
+  }
+
+  /**
+   * Determine if schemas are loaded and invalid
+   */
+  public get schemasLoadedInvalid( ): boolean {
+    return this.schemaLoadingState === LoadingState.LOADED_INVALID;
+  }
+
+  /*
+   * Get all schemas
+   * @returns {CatalogSchema[]} the array of schema
+   */
+  public getSchemas(): CatalogSchema[] {
+    return this.schemas;
+  }
+
+  /**
+   * Determine if tables are loading
+   */
+  public get tablesLoading( ): boolean {
+    return this.tableLoadingState === LoadingState.LOADING;
+  }
+
+  /**
+   * Determine if tables are loaded, valid and not empty
+   */
+  public get tablesLoadedValidNotEmpty( ): boolean {
+    return (this.tableLoadingState === LoadingState.LOADED_VALID) && this.tables.length > 0;
+  }
+
+  /**
+   * Determine if tables are loaded, valid but empty
+   */
+  public get tablesLoadedValidEmpty( ): boolean {
+    return (this.tableLoadingState === LoadingState.LOADED_VALID) && this.tables.length === 0;
+  }
+
+  /**
+   * Determine if tables are loaded and invalid
+   */
+  public get tablesLoadedInvalid( ): boolean {
+    return this.tableLoadingState === LoadingState.LOADED_INVALID;
+  }
+
+  /*
+   * Get all tables
+   * @returns {Table[]} the current tables for the selected schema
+   */
+  public getTables(): Table[] {
+    return this.tables;
+  }
+
+  /*
+   * Determine if any tables are currently selected
+   * @returns {boolean} true if one or more tables are selected
+   */
+  public hasSelectedTables(): boolean {
+    return this.getSelectedTables().length > 0;
+  }
+
+  /*
+   * Get the array of currently selected Tables
+   * @returns {Table[]} the array of selected Tables
+   */
+  public getSelectedTables(): Table[] {
+    const selectedTables = [];
+    for ( const tbl of this.getTables() ) {
+      if (tbl.selected) {
+        selectedTables.push(tbl);
+      }
+    }
+    return selectedTables;
+  }
+
+  /*
+   * Handler for changes in table selection
+   */
+  public selectedTablesChanged( ): void {
+    this.tableSelectionChanged.emit();
+  }
+
+  /*
+   * Builds the array of CatalogSchema items from the SchemaInfo coming from
+   * the Komodo rest call
+   * @param {SchemaInfo[]} infos the array of SchemaInfo from komodo
+   */
+  private generateSchemaNames(infos: SchemaInfo[]): void {
+    for (const info of infos) {
+      const infoName = info.getName();
+      const infoType = info.getType();
+      const schemaNames = info.getSchemaNames();
+      if (infoType === "Catalog") {
+        if (schemaNames && schemaNames.length > 0) {
+          for (const sName of schemaNames) {
+            const item: CatalogSchema = new CatalogSchema();
+            item.setName(sName);
+            item.setType("Schema");
+            item.setCatalogName(infoName);
+            this.schemas.push(item);
+          }
+        } else {
+          const item: CatalogSchema = new CatalogSchema();
+          item.setName(infoName);
+          item.setType("Catalog");
+          this.schemas.push(item);
+        }
+      } else if (infoType === "Schema") {
+        const item: CatalogSchema = new CatalogSchema();
+        item.setName(infoName);
+        item.setType("Schema");
+        this.schemas.push(item);
+      }
+    }
+  }
+
+  /*
+   * Populates tables array, given the supplied JdbcTableFilter
+   * @para {JdbcTableFilter} tableFilter the filters for getting tables
+   */
+  private loadTablesForSchema(tableFilter: JdbcTableFilter): void {
+    // Load the table names for the selected Connection and Schema
+    this.tables = [];
+    this.tableLoadingState = LoadingState.LOADING;
+    const self = this;
+    this.connectionService
+      .getJdbcConnectionTables(tableFilter)
+      .subscribe(
+        (tableNames) => {
+          for ( const tName of tableNames ) {
+            const table = new Table();
+            table.setName(tName);
+            table.setConnection(self.connection);
+            table.setCatalogName(self.selectedSchema.getCatalogName());
+            table.setSchemaName(self.selectedSchema.getName());
+            self.tables.push(table);
+          }
+          self.tableLoadingState = LoadingState.LOADED_VALID;
+        },
+        (error) => {
+          self.logger.error("[JdbcTableSelectorComponent] Error getting tables: %o", error);
+          self.tableLoadingState = LoadingState.LOADED_INVALID;
+        }
+      );
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/catalog-schema.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/catalog-schema.model.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * CatalogSchema model.  The type will be 'Catalog' or 'Schema'.  For Schema, the catalogName may
+ * or may not be set depending on whether Catalogs are supported.
+ */
+export class CatalogSchema {
+  private name: string;
+  private type: string;
+  private catalogName: string;
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the info name
+   */
+  public getName(): string {
+    return this.name;
+  }
+
+  /**
+   * @returns {string} the info type
+   */
+  public getType(): string {
+    return this.type;
+  }
+
+  /**
+   * @returns {string} the catalog name
+   */
+  public getCatalogName(): string {
+    return this.catalogName;
+  }
+
+  /**
+   * @returns {string} the display name
+   */
+  public getDisplayName(): string {
+    const type = this.getType();
+    if ( type === "Catalog" ) {
+      return this.getName();
+    } else if ( type === "Schema" ) {
+      const catalog = this.getCatalogName();
+      if ( catalog && catalog.length > 0 ) {
+        return catalog + "." + this.getName();
+      } else {
+        return this.getName();
+      }
+    }
+    return this.catalogName;
+  }
+
+  /**
+   * @param {string} name the name
+   */
+  public setName( name?: string ): void {
+    this.name = name ? name : null;
+  }
+
+  /**
+   * @param {string} type the type
+   */
+  public setType( type?: string ): void {
+    this.type = type ? type : null;
+  }
+
+  /**
+   * @param {string} name the name of the catalog
+   */
+  public setCatalogName( name?: string ): void {
+    this.catalogName = name ? name : null;
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { ReflectiveInjector } from "@angular/core";
+import { AppSettingsService } from "@core/app-settings.service";
 import { Identifiable } from "@shared/identifiable";
 import { SortDirection } from "@shared/sort-direction.enum";
 
@@ -22,6 +24,7 @@ export class Dataservice implements Identifiable< string > {
 
   private keng__id: string;
   private tko__description: string;
+  private appSettings: AppSettingsService;
 
   /**
    * @param {Object} json the JSON representation of a Dataservice
@@ -50,8 +53,9 @@ export class Dataservice implements Identifiable< string > {
     } );
   }
 
-  constructor() {
-    // nothing to do
+  constructor( ) {
+    const injector = ReflectiveInjector.resolveAndCreate([AppSettingsService]);
+    this.appSettings = injector.get(AppSettingsService);
   }
 
   /**
@@ -94,7 +98,7 @@ export class Dataservice implements Identifiable< string > {
    * @returns {string} the dataservice dataPath (can be null)
    */
   public getDataPath(): string {
-    return "/tko:komodo/tko:workspace/dsbUser/" + this.keng__id;
+    return this.appSettings.getKomodoUserWorkspacePath() + "/" + this.keng__id;
   }
 
   /**
@@ -116,6 +120,14 @@ export class Dataservice implements Identifiable< string > {
    */
   public setDescription( description?: string ): void {
     this.tko__description = description ? description : null;
+  }
+
+  // overrides toJSON - we do not want the appSettings
+  public toJSON(): {} {
+    return {
+      keng__id: this.keng__id,
+      tko__description: this.tko__description
+    };
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.spec.ts
@@ -1,17 +1,22 @@
 import { inject, TestBed } from "@angular/core/testing";
 import { HttpModule } from "@angular/http";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 
 describe("DataserviceService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpModule ],
-      providers: [DataserviceService, LoggerService]
+      providers: [DataserviceService, AppSettingsService, LoggerService,
+        { provide: VdbService, useClass: MockVdbService }
+      ]
     });
   });
 
-  it("should be created", inject([DataserviceService, LoggerService],
+  it("should be created", inject([DataserviceService, AppSettingsService, LoggerService],
                                             ( service: DataserviceService ) => {
     expect(service).toBeTruthy();
   }));

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
@@ -18,21 +18,29 @@
 import { Injectable } from "@angular/core";
 import { Http } from "@angular/http";
 import { ApiService } from "@core/api.service";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
 import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
 import { NewDataservice } from "@dataservices/shared/new-dataservice.model";
+import { Table } from "@dataservices/shared/table.model";
+import { VdbService } from "@dataservices/shared/vdb.service";
+import { VdbsConstants } from "@dataservices/shared/vdbs-constants";
 import { environment } from "@environments/environment";
 import { Observable } from "rxjs/Observable";
 
 @Injectable()
 export class DataserviceService extends ApiService {
 
-  private http: Http;
+  public serviceVdbSuffix = "VDB";  // Don't change - must match komodo naming convention
 
-  constructor( http: Http, logger: LoggerService ) {
-    super( logger  );
+  private http: Http;
+  private vdbService: VdbService;
+
+  constructor( http: Http, vdbService: VdbService, appSettings: AppSettingsService, logger: LoggerService ) {
+    super( appSettings, logger  );
     this.http = http;
+    this.vdbService = vdbService;
   }
 
   /**
@@ -57,7 +65,87 @@ export class DataserviceService extends ApiService {
   public createDataservice(dataservice: NewDataservice): Observable<boolean> {
     return this.http
       .post(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRootPath + "/" + dataservice.getId(),
-             dataservice, this.getAuthRequestOptions())
+        dataservice, this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Create a dataservice via the komodo rest interface
+   * @param {string} dataserviceName,
+   * @param {string} tablePath,
+   * @param {string} modelSourcePath,
+   * @returns {Observable<boolean>}
+   */
+  public setServiceVdbForSingleTable(dataserviceName: string, tablePath: string, modelSourcePath: string): Observable<boolean> {
+    return this.http
+      .post(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRootPath + "/ServiceVdbForSingleTable",
+        { dataserviceName, tablePath, modelSourcePath}, this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Create a readonly datarole for the dataservice
+   * @param {string} dataserviceName,
+   * @param {string} model1Name,
+   * @returns {Observable<boolean>}
+   */
+  public createReadonlyDataRole(dataserviceName: string, model1Name: string): Observable<boolean> {
+    const serviceVdbName = dataserviceName + this.serviceVdbSuffix;
+    const READ_ONLY_DATA_ROLE_NAME = VdbsConstants.DEFAULT_READONLY_DATA_ROLE;
+    const VIEW_MODEL = VdbsConstants.SERVICE_VIEW_MODEL_NAME;
+    const userWorkspacePath = this.getKomodoUserWorkspacePath();
+
+    // The payload for the rest call
+    const payload = {
+      "keng__id": READ_ONLY_DATA_ROLE_NAME,
+      "keng__kType": "VdbDataRole",
+      "keng__dataPath": userWorkspacePath + "/" + serviceVdbName + "/vdb:dataRoles/" + READ_ONLY_DATA_ROLE_NAME,
+      "vdb__dataRole": READ_ONLY_DATA_ROLE_NAME,
+      "vdb__description": "The default read-only access data role.",
+      "vdb__grantAll": false,
+      "vdb__anyAuthenticated": true,
+      "vdb__allowCreateTemporaryTables": false,
+      "vdb__permissions": [
+        {
+          "keng__id": VIEW_MODEL,
+          "keng__kType": "VdbPermission",
+          "keng__dataPath": userWorkspacePath + "/" + serviceVdbName + "/vdb:dataRoles/" + READ_ONLY_DATA_ROLE_NAME
+                                              + "/vdb:permissions/" + VIEW_MODEL,
+          "vdb__permission": VIEW_MODEL,
+          "vdb__allowAlter": false,
+          "vdb__allowCreate": false,
+          "vdb__allowDelete": false,
+          "vdb__allowExecute": false,
+          "vdb__allowRead": true,
+          "vdb__allowUpdate": false
+        },
+        {
+          "keng__id": model1Name,
+          "keng__kType": "VdbPermission",
+          "keng__dataPath": userWorkspacePath + "/" + serviceVdbName + "/vdb:dataRoles/" + READ_ONLY_DATA_ROLE_NAME
+                                              + "/vdb:permissions/" + model1Name,
+          "vdb__permission": model1Name,
+          "vdb__allowAlter": false,
+          "vdb__allowCreate": false,
+          "vdb__allowDelete": false,
+          "vdb__allowExecute": false,
+          "vdb__allowRead": true,
+          "vdb__allowUpdate": false
+        }
+      ]
+    };
+    const url = environment.komodoWorkspaceUrl + VdbsConstants.vdbsRootPath + "/" + serviceVdbName
+                                               + "/VdbDataRoles/" + READ_ONLY_DATA_ROLE_NAME;
+    const paystr = JSON.stringify(payload);
+
+    return this.http
+      .post(url, paystr, this.getAuthRequestOptions())
       .map((response) => {
         return response.ok;
       })
@@ -77,6 +165,30 @@ export class DataserviceService extends ApiService {
         return response.ok;
       })
       .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Create a dataservice which is a straight passthru to the supplied tables
+   * @param {NewDataservice} dataservice
+   * @param {Table} sourceTable
+   * @returns {Observable<boolean>}
+   */
+  public createDataserviceForSingleTable(dataservice: NewDataservice, sourceTable: Table): Observable<boolean> {
+    const connectionName = sourceTable.getConnection().getId();
+    const sourceVdbName = connectionName + VdbsConstants.SOURCE_VDB_SUFFIX;
+    const sourceModelName = connectionName;
+    const vdbPath = this.getKomodoUserWorkspacePath() + "/" + sourceVdbName;
+    const tablePath = vdbPath + "/" + sourceModelName + "/" + sourceTable.getName();
+    const modelSourcePath = vdbPath + "/" + sourceModelName + "/vdb:sources/" + sourceModelName;
+
+    // Chain the individual calls together in series to build the DataService
+    return this.createDataservice(dataservice)
+      .flatMap((res) => this.vdbService.updateVdbModelFromTeiid(sourceVdbName, sourceModelName,
+                                                                sourceVdbName, sourceModelName))
+      .flatMap((res) => this.setServiceVdbForSingleTable(dataservice.getId(), tablePath, modelSourcePath))
+      .flatMap((res) => this.createReadonlyDataRole(dataservice.getId(), sourceModelName))
+      .flatMap((res) => this.vdbService.undeployVdb(sourceVdbName))
+      .flatMap((res) => this.vdbService.deleteVdb(sourceVdbName));
   }
 
 }

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -1,9 +1,28 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Injectable } from "@angular/core";
 import { Http } from "@angular/http";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { NewDataservice } from "@dataservices/shared/new-dataservice.model";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import "rxjs/add/observable/of";
 import "rxjs/add/observable/throw";
 import "rxjs/add/operator/catch";
@@ -18,8 +37,8 @@ export class MockDataserviceService extends DataserviceService {
   private serv3 = new Dataservice();
   private services: Dataservice[] = [this.serv1, this.serv2, this.serv3];
 
-  constructor( http: Http, logger: LoggerService ) {
-    super(http, logger);
+  constructor( http: Http, vdbService: VdbService, appSettings: AppSettingsService, logger: LoggerService ) {
+    super(http, vdbService, appSettings, logger);
     this.serv1.setId("serv1");
     this.serv2.setId("serv2");
     this.serv3.setId("serv3");

--- a/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { Http } from "@angular/http";
+import { AppSettingsService } from "@core/app-settings.service";
+import { LoggerService } from "@core/logger.service";
+import { Table } from "@dataservices/shared/table.model";
+import { VdbModelSource } from "@dataservices/shared/vdb-model-source.model";
+import { VdbModel } from "@dataservices/shared/vdb-model.model";
+import { VdbStatus } from "@dataservices/shared/vdb-status.model";
+import { Vdb } from "@dataservices/shared/vdb.model";
+import { VdbService } from "@dataservices/shared/vdb.service";
+import "rxjs/add/observable/of";
+import "rxjs/add/observable/throw";
+import "rxjs/add/operator/catch";
+import "rxjs/add/operator/map";
+import { Observable } from "rxjs/Observable";
+
+@Injectable()
+export class MockVdbService extends VdbService {
+
+  private vdb1 = new Vdb();
+  private vdb2 = new Vdb();
+  private vdb3 = new Vdb();
+  private vdbs: Vdb[] = [this.vdb1, this.vdb2, this.vdb3];
+
+  private vdbStatus1 = new VdbStatus();
+  private vdbStatus2 = new VdbStatus();
+  private vdbStatus3 = new VdbStatus();
+  private statuses: VdbStatus[] = [this.vdbStatus1, this.vdbStatus3, this.vdbStatus3];
+
+  constructor( http: Http, appSettings: AppSettingsService, logger: LoggerService ) {
+    super(http, appSettings, logger);
+    this.vdb1.setId("serv1");
+    this.vdb2.setId("serv2");
+    this.vdb3.setId("serv3");
+  }
+
+  /**
+   * Get the vdbs from the komodo rest interface
+   * @returns {Observable<Vdb[]>}
+   */
+  public getVdbs(): Observable<Vdb[]> {
+    return Observable.of(this.vdbs);
+  }
+
+  /**
+   * Get the vdbs from the komodo rest interface
+   * @returns {Observable<Vdb[]>}
+   */
+  public getTeiidVdbStatuses(): Observable<VdbStatus[]> {
+    return Observable.of(this.statuses);
+  }
+
+  /**
+   * Create a vdb via the komodo rest interface
+   * @param {Vdb} vdb
+   * @returns {Observable<boolean>}
+   */
+  public createVdb(vdb: Vdb): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Create a vdb via the komodo rest interface
+   * @param {string} vdbName
+   * @param {VdbModel} vdbModel
+   * @returns {Observable<boolean>}
+   */
+  public createVdbModel(vdbName: string, vdbModel: VdbModel): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Create a vdbModelSource via the komodo rest interface
+   * @param {string} vdbName the vdb name
+   * @param {string} modelName the model name
+   * @param {VdbModelSource} vdbModelSource the modelsource name
+   * @returns {Observable<boolean>}
+   */
+  public createVdbModelSource(vdbName: string, modelName: string, vdbModelSource: VdbModelSource): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Delete a vdb via the komodo rest interface
+   * @param {string} vdbId
+   * @returns {Observable<boolean>}
+   */
+  public deleteVdb(vdbId: string): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Deploys the workspace VDB with the provided name
+   * @param {string} vdbName
+   * @returns {Observable<boolean>}
+   */
+  public deployVdb(vdbName: string): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Undeploy a vdb from the teiid server
+   * @param {string} vdbId
+   * @returns {Observable<boolean>}
+   */
+  public undeployVdb(vdbId: string): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Update the specified repo VDB Model using the DDL from the specified Teiid VDB
+   * @param {string} vdbName the VDB in the repo to update
+   * @param {string} modelName the Model withing the specified repo VDB
+   * @param {string} teiidVdbName the deployed teiid VDB name
+   * @param {string} teiidModelName the teiid VDB Model name
+   * @returns {Observable<boolean>}
+   */
+  public updateVdbModelFromTeiid(vdbName: string, modelName: string,
+                                 teiidVdbName: string, teiidModelName: string): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Polls the server for the specified VDB.  Polling will terminate if
+   * (1) The VDB is active
+   * (2) The VDB is in a failed state
+   * (3) The polling duration has lapsed
+   * @param {string} vdbName the name of the VDB
+   * @param {number} pollDurationSec the duration (sec) to poll the server
+   * @param {number} pollIntervalSec the interval (sec) between polling attempts
+   */
+  public pollForActiveVdb(vdbName: string, pollDurationSec: number, pollIntervalSec: number): void {
+    return;
+  }
+
+  /**
+   * Create and deploy a VDB for the provided table
+   * @param {Table} table
+   * @returns {Observable<boolean>}
+   */
+  public deployVdbForTable(table: Table): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/name-value.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/name-value.model.ts
@@ -15,15 +15,17 @@
  * limitations under the License.
  */
 
-import { enableProdMode } from "@angular/core";
-import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-import { AppModule } from "@app/app.module";
-import { environment } from "@environments/environment";
+/**
+ * A model for holding simple name-value pairs.
+ */
+export class NameValue {
 
-if (environment.production) {
-  enableProdMode();
+  private name: string;
+  private value: string;
+
+  constructor(name: string, value: string) {
+    this.name = name;
+    this.value = value;
+  }
+
 }
-
-platformBrowserDynamic().bootstrapModule( AppModule )
-                        .then( (success) => console.log( `Bootstrap success` ) )
-                        .catch( (err) => console.error( err ) );

--- a/src/main/ngapp/src/app/dataservices/shared/new-dataservice.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/new-dataservice.model.ts
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ReflectiveInjector } from "@angular/core";
+import { AppSettingsService } from "@core/app-settings.service";
 
 export class NewDataservice {
 
@@ -21,12 +23,15 @@ export class NewDataservice {
   private keng__dataPath: string;
   private keng__kType: string;
   private tko__description: string;
+  private appSettings: AppSettingsService;
 
   /**
    * Constructor
    */
-  constructor() {
+  constructor( ) {
     this.keng__kType = "Dataservice";
+    const injector = ReflectiveInjector.resolveAndCreate([AppSettingsService]);
+    this.appSettings = injector.get(AppSettingsService);
   }
 
   /**
@@ -48,7 +53,7 @@ export class NewDataservice {
    */
   public setId( name: string ): void {
     this.keng__id = name;
-    this.keng__dataPath = "/tko:komodo/tko:workspace/dsbUser/" + name;
+    this.keng__dataPath = this.appSettings.getKomodoUserWorkspacePath() + "/" + name;
   }
 
   /**
@@ -56,5 +61,15 @@ export class NewDataservice {
    */
   public setDescription( description?: string ): void {
     this.tko__description = description ? description : null;
+  }
+
+  // overrides toJSON - we do not want the appSettings
+  public toJSON(): {} {
+    return {
+      keng__id: this.keng__id,
+      keng__dataPath: this.keng__dataPath,
+      keng__kType: this.keng__kType,
+      tko__description: this.tko__description
+    };
   }
 }

--- a/src/main/ngapp/src/app/dataservices/shared/table-selector.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/table-selector.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Connection } from "@connections/shared/connection.model";
+import { Table } from "@dataservices/shared/table.model";
+
+/**
+ * The table selector interface
+ */
+export interface TableSelector {
+
+  /*
+   * Set the connection for this jdbc table selector
+   * @param {Connection} conn the jdbc connection
+   */
+  setConnection(conn: Connection): void;
+
+  /*
+   * Determine if any tables are currently selected
+   * @returns {boolean} true if one or more tables are selected
+   */
+  hasSelectedTables( ): boolean;
+
+  /*
+   * Get the array of currently selected Tables
+   * @returns {Table[]} the array of selected Tables (never null, but may be empty)
+   */
+  getSelectedTables(): Table[];
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/table.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/table.model.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Connection } from "@connections/shared/connection.model";
+
+/**
+ * Table model
+ */
+export class Table {
+  private name: string;
+  private connection: Connection;
+  private catalogName: string;
+  private schemaName: string;
+  private isSelected = false;
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the table name
+   */
+  public getName(): string {
+    return this.name;
+  }
+
+  /**
+   * @param {string} name the table name
+   */
+  public setName( name?: string ): void {
+    this.name = name ? name : null;
+  }
+
+  /**
+   * @returns {Connection} the connection for the table
+   */
+  public getConnection(): Connection {
+    return this.connection;
+  }
+
+  /**
+   * @param {string} connection the connection for the table
+   */
+  public setConnection( connection?: Connection ): void {
+    this.connection = connection ? connection : null;
+  }
+
+  /**
+   * @returns {string} the catalog name for the table
+   */
+  public getCatalogName(): string {
+    return this.catalogName;
+  }
+
+  /**
+   * @param {string} catalogName the connection name for the table
+   */
+  public setCatalogName( catalogName?: string ): void {
+    this.catalogName = catalogName ? catalogName : null;
+  }
+
+  /**
+   * @returns {string} the schema name for the table
+   */
+  public getSchemaName(): string {
+    return this.schemaName;
+  }
+
+  /**
+   * @param {string} schemaName the schema name for the table
+   */
+  public setSchemaName( schemaName?: string ): void {
+    this.schemaName = schemaName ? schemaName : null;
+  }
+
+  /**
+   * @returns {boolean} true if selected
+   */
+  public get selected(): boolean {
+    return this.isSelected;
+  }
+
+  /**
+   * @param {boolean} selected 'true' if selected
+   */
+  public set selected( selected: boolean ) {
+    this.isSelected = selected;
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/vdb-model-source.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb-model-source.model.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * VdbModelSource model
+ */
+export class VdbModelSource {
+
+  private keng__id: string;
+  private keng__dataPath: string;
+  private keng__kType = "VdbModelSource";
+  private vdb__sourceJndiName: string;
+  private vdb__sourceTranslator: string;
+
+  /**
+   * @param {Object} json the JSON representation of a VdbModelSource
+   * @returns {VdbModelSource} the new VdbModelSource (never null)
+   */
+  public static create( json: object = {} ): VdbModelSource {
+    const vdbModelSource = new VdbModelSource();
+    vdbModelSource.setValues( json );
+    return vdbModelSource;
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the vdbModelSource identifier (can be null)
+   */
+  public getId(): string {
+    return this.keng__id;
+  }
+
+  /**
+   * @returns {string} the vdbModelSource dataPath (can be null)
+   */
+  public getDataPath(): string {
+    return this.keng__dataPath;
+  }
+
+  /**
+   * @returns {string} the vdbModelSource type name (can be null)
+   */
+  public getType(): string {
+    return this.keng__kType;
+  }
+
+  /**
+   * @returns {string} the jndi name (can be null)
+   */
+  public getJndiName(): string {
+    return this.vdb__sourceJndiName;
+  }
+
+  /**
+   * @returns {string} the translator name (can be null)
+   */
+  public getTranslatorName(): string {
+    return this.vdb__sourceTranslator;
+  }
+
+  /**
+   * @param {string} id the vdbModelSource identifier (optional)
+   */
+  public setId( id?: string ): void {
+    this.keng__id = id ? id : null;
+  }
+
+  /**
+   * @param {string} dataPath the vdbModelSource dataPath (optional)
+   */
+  public setDataPath( dataPath?: string ): void {
+    this.keng__dataPath = dataPath ? dataPath : null;
+  }
+
+  /**
+   * @param {string} jndiName the jndi name (optional)
+   */
+  public setJndiName( jndiName?: string ): void {
+    this.vdb__sourceJndiName = jndiName ? jndiName : null;
+  }
+
+  /**
+   * @param {string} translator the translator name (optional)
+   */
+  public setTranslatorName( translator?: string ): void {
+    this.vdb__sourceTranslator = translator ? translator : null;
+  }
+
+  /**
+   * Set all object values using the supplied VdbModelSource json
+   * @param {Object} values
+   */
+  public setValues(values: object = {}): void {
+    Object.assign(this, values);
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/vdb-model.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb-model.model.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NameValue } from "@dataservices/shared/name-value.model";
+
+/**
+ * VdbModel model
+ */
+export class VdbModel {
+
+  private keng__id: string;
+  private keng__dataPath: string;
+  private keng__kType = "VdbModel";
+  private mmcore__modelType: string;
+  // noinspection JSMismatchedCollectionQueryUpdate
+  private keng__properties: NameValue[] = [];
+
+  /**
+   * @param {Object} json the JSON representation of a VdbModel
+   * @returns {VdbModel} the new VdbModel (never null)
+   */
+  public static create( json: object = {} ): VdbModel {
+    const vdbModel = new VdbModel();
+    vdbModel.setValues( json );
+    return vdbModel;
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the vdbModel identifier (can be null)
+   */
+  public getId(): string {
+    return this.keng__id;
+  }
+
+  /**
+   * @returns {string} the vdbModel dataPath (can be null)
+   */
+  public getDataPath(): string {
+    return this.keng__dataPath;
+  }
+
+  /**
+   * @returns {string} the vdbModel type name (can be null)
+   */
+  public getType(): string {
+    return this.keng__kType;
+  }
+
+  /**
+   * @returns {string} the vdbModel model type
+   */
+  public getModelType(): string {
+    return this.mmcore__modelType;
+  }
+
+  /**
+   * @param {string} id the vdbModel identifier (optional)
+   */
+  public setId( id?: string ): void {
+    this.keng__id = id ? id : null;
+  }
+
+  /**
+   * @param {string} dataPath the vdbModel dataPath (optional)
+   */
+  public setDataPath( dataPath?: string ): void {
+    this.keng__dataPath = dataPath ? dataPath : null;
+  }
+
+  /**
+   * @param {string} modelType the vdbModel type
+   */
+  public setModelType( modelType: string ): void {
+    this.mmcore__modelType = modelType;
+  }
+
+  /**
+   * @param {NameValue[]} props the model properties (optional)
+   */
+  public setProperties( props?: NameValue[] ): void {
+    this.keng__properties = props ? props : null;
+  }
+
+  /**
+   * Set all object values using the supplied VdbModel json
+   * @param {Object} values
+   */
+  public setValues(values: object = {}): void {
+    Object.assign(this, values);
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/vdb-status.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb-status.model.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * VdbStatus model
+ */
+export class VdbStatus {
+
+  private name: string;
+  private deployedName: string;
+  private version = "1";
+  private active = false;
+  private loading = false;
+  private failed = false;
+  private errors: string[] = [];
+
+  /**
+   * @param {Object} json the JSON representation of a VdbStatus
+   * @returns {VdbStatus} the new VdbStatus (never null)
+   */
+  public static create( json: object = {} ): VdbStatus {
+    const vdbStatus = new VdbStatus();
+    vdbStatus.setValues( json );
+    return vdbStatus;
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the vdbStatus name
+   */
+  public getName(): string {
+    return this.name;
+  }
+
+  /**
+   * @returns {string} the vdbStatus deployedName
+   */
+  public getDeployedName(): string {
+    return this.deployedName;
+  }
+
+  /**
+   * @returns {string} the vdbStatus version (can be null)
+   */
+  public getVersion(): string {
+    return this.version;
+  }
+
+  /**
+   * @returns {boolean} the vdbStatus active state
+   */
+  public isActive(): boolean {
+    return this.active;
+  }
+
+  /**
+   * @returns {boolean} the vdbStatus loading state
+   */
+  public isLoading(): boolean {
+    return this.loading;
+  }
+
+  /**
+   * @returns {boolean} the vdbStatus failed state
+   */
+  public isFailed(): boolean {
+    return this.failed;
+  }
+
+  /**
+   * @returns {string[]} the errors (never null)
+   */
+  public getErrors(): string[] {
+    return this.errors;
+  }
+
+  /**
+   * @param {string} name the vdbStatus name
+   */
+  public setName( name: string ): void {
+    this.name = name;
+  }
+
+  /**
+   * @param {string} deployedName the vdbStatus deployedName
+   */
+  public setDeployedName( deployedName: string ): void {
+    this.deployedName = deployedName;
+  }
+
+  /**
+   * @param {string} version the vdbStatus version (optional)
+   */
+  public setVersion( version?: string ): void {
+    this.version = version ? version : "1";
+  }
+
+  /**
+   * @param {boolean} active the active state
+   */
+  public setActive( active: boolean ): void {
+    this.active = active;
+  }
+
+  /**
+   * @param {boolean} loading the loading state
+   */
+  public setLoading( loading: boolean ): void {
+    this.loading = loading;
+  }
+
+  /**
+   * @param {boolean} failed the failed state
+   */
+  public setFailed( failed: boolean ): void {
+    this.failed = failed;
+  }
+
+  /**
+   * @param {[string]} errors the status errors
+   */
+  public setErrors( errors: string[] ): void {
+    this.errors = errors;
+  }
+
+  /**
+   * Set all object values using the supplied VdbStatus json
+   * @param {Object} values
+   */
+  public setValues(values: object = {}): void {
+    Object.assign(this, values);
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/vdb.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb.model.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Identifiable } from "@shared/identifiable";
+import { SortDirection } from "@shared/sort-direction.enum";
+
+/**
+ * Vdb model
+ */
+export class Vdb implements Identifiable< string > {
+
+  private keng__id: string;
+  private vdb__description: string;
+  private keng__dataPath: string;
+  private keng__kType = "Vdb";
+  private vdb__name: string;
+  private vdb__originalFile: string;
+  private vdb__preview: boolean;
+  private vdb__version: string;
+
+  /**
+   * @param {Object} json the JSON representation of a Vdb
+   * @returns {Vdb} the new Vdb (never null)
+   */
+  public static create( json: object = {} ): Vdb {
+    const vdb = new Vdb();
+    vdb.setValues( json );
+    return vdb;
+  }
+
+  /**
+   * @param {Vdb[]} vdbs the vdbs being sorted
+   * @param {SortDirection} sortDirection the sort direction
+   */
+  public static sort( vdbs: Vdb[],
+                      sortDirection: SortDirection ): void {
+    vdbs.sort( ( thisVdb: Vdb, thatVdb: Vdb ) => {
+      const result = thisVdb.compareTo( thatVdb );
+
+      if ( sortDirection === SortDirection.DESC ) {
+        return result * -1;
+      }
+
+      return result;
+    } );
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * See {Identifiable}.
+   */
+  public compareTo( that: Vdb ): number {
+    let result = 0;
+
+    if ( this.getId() ) {
+      if ( that.getId() ) {
+        // both have an ID
+        result = this.getId().localeCompare( that.getId() );
+      } else {
+        // thatItem does not have an ID
+        result = 1;
+      }
+    } else if ( that.getId() ) {
+      // thisItem does not have an ID and thatItem does
+      result = -1;
+    }
+
+    return result;
+  }
+
+  /**
+   * @returns {string} the vdb identifier (can be null)
+   */
+  public getId(): string {
+    return this.keng__id;
+  }
+
+  /**
+   * @returns {string} the vdb name (can be null)
+   */
+  public getName(): string {
+    return this.vdb__name;
+  }
+
+  /**
+   * @returns {string} the vdb description (can be null)
+   */
+  public getDescription(): string {
+    return this.vdb__description;
+  }
+
+  /**
+   * @returns {string} the vdb dataPath (can be null)
+   */
+  public getDataPath(): string {
+    return this.keng__dataPath;
+  }
+
+  /**
+   * @returns {string} the vdb originalFile (can be null)
+   */
+  public getOriginalFile(): string {
+    return this.vdb__originalFile;
+  }
+
+  /**
+   * @returns {string} the vdb type name (can be null)
+   */
+  public getType(): string {
+    return this.keng__kType;
+  }
+
+  /**
+   * @returns {boolean} the vdb preview status
+   */
+  public isPreview(): boolean {
+    return this.vdb__preview;
+  }
+
+  /**
+   * @returns {string} the vdb type name (can be null)
+   */
+  public getVersion(): string {
+    return this.vdb__version;
+  }
+
+  /**
+   * @param {string} id the vdb identifier (optional)
+   */
+  public setId( id?: string ): void {
+    this.keng__id = id ? id : null;
+  }
+
+  /**
+   * @param {string} name the vdb name (optional)
+   */
+  public setName( name?: string ): void {
+    this.vdb__name = name ? name : null;
+  }
+
+  /**
+   * @param {string} description the vdb description (optional)
+   */
+  public setDescription( description?: string ): void {
+    this.vdb__description = description ? description : null;
+  }
+
+  /**
+   * @param {string} dataPath the vdb dataPath (optional)
+   */
+  public setDataPath( dataPath?: string ): void {
+    this.keng__dataPath = dataPath ? dataPath : null;
+  }
+
+  /**
+   * @param {string} originalFile the vdb originalFile (optional)
+   */
+  public setOriginalFile( originalFile?: string ): void {
+    this.vdb__originalFile = originalFile ? originalFile : null;
+  }
+
+  /**
+   * @param {boolean} preview the vdb preview status
+   */
+  public setPreview( preview: boolean ): void {
+    this.vdb__preview = preview;
+  }
+
+  /**
+   * @param {string} version the vdb version
+   */
+  public setVersion( version?: string ): void {
+    this.vdb__version = version;
+  }
+
+  /**
+   * Set all object values using the supplied Vdb json
+   * @param {Object} values
+   */
+  public setValues(values: object = {}): void {
+    Object.assign(this, values);
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/vdb.service.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb.service.spec.ts
@@ -1,19 +1,19 @@
 import { inject, TestBed } from "@angular/core/testing";
 import { HttpModule } from "@angular/http";
-import { ConnectionService } from "@connections/shared/connection.service";
 import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 
-describe("ConnectionService", () => {
+describe("VdbService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpModule ],
-      providers: [AppSettingsService, ConnectionService, LoggerService]
+      providers: [VdbService, AppSettingsService, LoggerService]
     });
   });
 
-  it("should be created", inject([ConnectionService, AppSettingsService, LoggerService],
-                                            (service: ConnectionService ) => {
+  it("should be created", inject([VdbService, AppSettingsService, LoggerService],
+                                            ( service: VdbService ) => {
     expect(service).toBeTruthy();
   }));
 });

--- a/src/main/ngapp/src/app/dataservices/shared/vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb.service.ts
@@ -1,0 +1,326 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { Http } from "@angular/http";
+import { Connection } from "@connections/shared/connection.model";
+import { ApiService } from "@core/api.service";
+import { AppSettingsService } from "@core/app-settings.service";
+import { LoggerService } from "@core/logger.service";
+import { NameValue } from "@dataservices/shared/name-value.model";
+import { Table } from "@dataservices/shared/table.model";
+import { VdbModelSource } from "@dataservices/shared/vdb-model-source.model";
+import { VdbModel } from "@dataservices/shared/vdb-model.model";
+import { VdbStatus } from "@dataservices/shared/vdb-status.model";
+import { Vdb } from "@dataservices/shared/vdb.model";
+import { VdbsConstants } from "@dataservices/shared/vdbs-constants";
+import { environment } from "@environments/environment";
+import { ReplaySubject } from "rxjs/ReplaySubject";
+import { Observable } from "rxjs/Rx";
+import { Subject } from "rxjs/Subject";
+import { Subscription } from "rxjs/Subscription";
+
+@Injectable()
+/**
+ * VdbService
+ */
+export class VdbService extends ApiService {
+
+  // Observable deployment status
+  // Using replay status with cache of 1, so subscribers dont get an initial value on subscription
+  public deploymentStatus: Subject<VdbStatus> = new ReplaySubject<VdbStatus>(1);
+
+  private http: Http;
+  private deploymentSubscription: Subscription;
+
+  constructor( http: Http, appSettings: AppSettingsService, logger: LoggerService ) {
+    super( appSettings, logger  );
+    this.http = http;
+  }
+
+  /**
+   * Get the vdbs from the komodo rest interface
+   * @returns {Observable<Vdb[]>}
+   */
+  public getVdbs(): Observable<Vdb[]> {
+    return this.http
+      .get(environment.komodoWorkspaceUrl + VdbsConstants.vdbsRootPath, this.getAuthRequestOptions())
+      .map((response) => {
+        const vdbs = response.json();
+        return vdbs.map((vdb) => Vdb.create( vdb ));
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Get the vdbs from the komodo rest interface
+   * @returns {Observable<Vdb[]>}
+   */
+  public getTeiidVdbStatuses(): Observable<VdbStatus[]> {
+    return this.http
+      .get(environment.komodoTeiidUrl + VdbsConstants.statusPath + VdbsConstants.vdbsRootPath, this.getAuthRequestOptions())
+      .map((response) => {
+        const vdbStatuses = response.json();
+        return vdbStatuses.vdbs.map((vdbStatus) => VdbStatus.create( vdbStatus ));
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Create a vdb via the komodo rest interface
+   * @param {Vdb} vdb
+   * @returns {Observable<boolean>}
+   */
+  public createVdb(vdb: Vdb): Observable<boolean> {
+    return this.http
+      .post(environment.komodoWorkspaceUrl + VdbsConstants.vdbsRootPath + "/" + vdb.getId(),
+        vdb, this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Create a vdb via the komodo rest interface
+   * @param {string} vdbName
+   * @param {VdbModel} vdbModel
+   * @returns {Observable<boolean>}
+   */
+  public createVdbModel(vdbName: string, vdbModel: VdbModel): Observable<boolean> {
+    const str = JSON.stringify(vdbModel);
+    return this.http
+      .post(environment.komodoWorkspaceUrl + VdbsConstants.vdbsRootPath + "/" + vdbName
+                                               + VdbsConstants.vdbModelsRootPath + "/" + vdbModel.getId(),
+        str, this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Create a vdbModelSource via the komodo rest interface
+   * @param {string} vdbName the vdb name
+   * @param {string} modelName the model name
+   * @param {VdbModelSource} vdbModelSource the modelsource name
+   * @returns {Observable<boolean>}
+   */
+  public createVdbModelSource(vdbName: string, modelName: string, vdbModelSource: VdbModelSource): Observable<boolean> {
+    return this.http
+      .post(environment.komodoWorkspaceUrl + VdbsConstants.vdbsRootPath + "/" + vdbName
+                                               + VdbsConstants.vdbModelsRootPath + "/" + modelName
+                                               + VdbsConstants.vdbModelSourcesRootPath + "/" + vdbModelSource.getId(),
+        vdbModelSource, this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Delete a vdb via the komodo rest interface
+   * @param {string} vdbId
+   * @returns {Observable<boolean>}
+   */
+  public deleteVdb(vdbId: string): Observable<boolean> {
+    return this.http
+      .delete(environment.komodoWorkspaceUrl + VdbsConstants.vdbsRootPath + "/" + vdbId,
+               this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Deploys the workspace VDB with the provided name
+   * @param {string} vdbName
+   * @returns {Observable<boolean>}
+   */
+  public deployVdb(vdbName: string): Observable<boolean> {
+    const vdbPath = this.getKomodoUserWorkspacePath() + "/" + vdbName;
+    return this.http
+      .post(environment.komodoTeiidUrl + VdbsConstants.vdbRootPath,
+        { path: vdbPath}, this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Undeploy a vdb from the teiid server
+   * @param {string} vdbId
+   * @returns {Observable<boolean>}
+   */
+  public undeployVdb(vdbId: string): Observable<boolean> {
+    return this.http
+      .delete(environment.komodoTeiidUrl + VdbsConstants.vdbsRootPath + "/" + vdbId,
+        this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Update the specified repo VDB Model using the DDL from the specified Teiid VDB
+   * @param {string} vdbName the VDB in the repo to update
+   * @param {string} modelName the Model withing the specified repo VDB
+   * @param {string} teiidVdbName the deployed teiid VDB name
+   * @param {string} teiidModelName the teiid VDB Model name
+   * @returns {Observable<boolean>}
+   */
+  public updateVdbModelFromTeiid(vdbName: string, modelName: string,
+                                 teiidVdbName: string, teiidModelName: string): Observable<boolean> {
+    return this.http
+      .post(environment.komodoTeiidUrl + VdbsConstants.vdbsRootPath + "/ModelFromTeiidDdl",
+        { vdbName, modelName, teiidVdbName, teiidModelName }, this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
+   * Polls the server for the specified VDB.  Polling will terminate if
+   * (1) The VDB is active
+   * (2) The VDB is in a failed state
+   * (3) The polling duration has lapsed
+   * @param {string} vdbName the name of the VDB
+   * @param {number} pollDurationSec the duration (sec) to poll the server
+   * @param {number} pollIntervalSec the interval (sec) between polling attempts
+   */
+  public pollForActiveVdb(vdbName: string, pollDurationSec: number, pollIntervalSec: number): void {
+    const pollIntervalMillis = pollIntervalSec * 1000;
+    const pollIterations = pollDurationSec / pollIntervalSec;
+
+    let pollCount = 0;
+    const self = this;
+    // start a timer after one second
+    const timer = Observable.timer(1000, pollIntervalMillis);
+    this.deploymentSubscription = timer.subscribe((t: any) => {
+      this.getTeiidVdbStatuses()
+        .subscribe(
+          (resp) => {
+            for ( const vdbStatus of resp ) {
+              if ( vdbStatus.getName() !== vdbName ) {
+                continue;
+              }
+              if ( vdbStatus.isActive() ) {
+                self.broadcastDeploymentChange(vdbStatus);
+              } else if ( vdbStatus.isFailed() ) {
+                self.broadcastDeploymentChange(vdbStatus);
+              }
+            }
+            pollCount++;
+            if (pollCount > pollIterations) {
+              // Timed out status
+              const status: VdbStatus = new VdbStatus();
+              status.setName(vdbName);
+              status.setActive(false);
+              status.setLoading(false);
+              status.setFailed(true);
+              const errors: string[] = [];
+              errors.push("Deployment polling timed out");
+              status.setErrors(errors);
+              // broadcast the status
+              self.broadcastDeploymentChange(status);
+            }
+          },
+          (error) => {
+            // Error status
+            const status: VdbStatus = new VdbStatus();
+            status.setName(vdbName);
+            status.setActive(false);
+            status.setLoading(false);
+            status.setFailed(true);
+            const errors: string[] = [];
+            errors.push("Deployment failed");
+            status.setErrors(errors);
+            // Broadcast the status
+            self.broadcastDeploymentChange(status);
+          }
+        );
+    });
+  }
+
+  /**
+   * Create and deploy a VDB for the provided table
+   * @param {Table} table
+   * @returns {Observable<boolean>}
+   */
+  public deployVdbForTable(table: Table): Observable<boolean> {
+    const connection: Connection = table.getConnection();
+
+    // VDB to create
+    const vdb = new Vdb();
+    const vdbName = connection.getId() + VdbsConstants.SOURCE_VDB_SUFFIX;
+    const connName = connection.getId();
+    vdb.setName(vdbName);
+    vdb.setId(vdbName);
+    const vdbPath = this.getKomodoUserWorkspacePath() + "/" + vdbName;
+    vdb.setDataPath(vdbPath);
+    vdb.setOriginalFile(vdbPath);
+    vdb.setDescription(vdbName + " description");
+
+    // VDB Model to create
+    const vdbModel = new VdbModel();
+    vdbModel.setId(connName);
+    vdbModel.setDataPath(vdbPath + "/" + connName);
+    vdbModel.setModelType("PHYSICAL");
+    // Filter values for the model
+    let catName = table.getCatalogName();
+    let schemaName = table.getSchemaName();
+    let tableName = table.getName();
+    catName = (!catName || catName.length < 1) ? "%" : catName;
+    schemaName = (!schemaName || schemaName.length < 1) ? "%" : schemaName;
+    tableName = (!tableName || tableName.length < 1) ? "%" : tableName;
+    // Set the importer properties for the physical model
+    const props: NameValue[] = [];
+    props.push(new NameValue("importer.TableTypes", "TABLE"));
+    props.push(new NameValue("importer.UseFullSchemaName", "false"));
+    props.push(new NameValue("importer.UseQualifiedName", "false"));
+    props.push(new NameValue("importer.UseCatalogName", "false"));
+    props.push(new NameValue("importer.catalog", catName));
+    props.push(new NameValue("importer.schemaPattern", schemaName));
+    props.push(new NameValue("importer.tableNamePattern", tableName));
+    vdbModel.setProperties(props);
+
+    // VdbModelSource to create
+    const vdbModelSource = new VdbModelSource();
+    vdbModelSource.setId(connName);
+    vdbModelSource.setDataPath(vdbPath + "/" + connName + "/vdb:sources/" + connName);
+    vdbModelSource.setJndiName(connection.getJndiName());
+    vdbModelSource.setTranslatorName(connection.getDriverName());
+
+    // Chain the individual calls together in series to build the Vdb and deploy it
+    return this.createVdb(vdb)
+      .flatMap((res) => this.createVdbModel(vdb.getId(), vdbModel))
+      .flatMap((res) => this.createVdbModelSource(vdb.getId(), vdbModel.getId(), vdbModelSource))
+      .flatMap((res) => this.deployVdb(vdb.getId()));
+  }
+
+  // Broadcast of the deployment status changes
+  private broadcastDeploymentChange(status: VdbStatus): void {
+    this.deploymentSubscription.unsubscribe();
+    this.deploymentStatus.next(status);
+    this.deploymentStatus.next(null);
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/vdbs-constants.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdbs-constants.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, /
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class VdbsConstants {
+
+  public static readonly SERVICE_VIEW_MODEL_NAME = "views";  // ** must match KomodoDataserviceService.SERVICE_VDB_VIEW_MODEL **
+  public static readonly SOURCE_VDB_SUFFIX = "SvcSource";
+  public static readonly DEFAULT_READONLY_DATA_ROLE = "DefaultReadOnlyDataRole";
+
+  public static readonly statusPath = "/status";
+
+  public static readonly vdbRootRoute = "vdb";
+  public static readonly vdbRootPath = "/" + VdbsConstants.vdbRootRoute;
+
+  public static readonly vdbsRootRoute = "vdbs";
+  public static readonly vdbsRootPath = "/" + VdbsConstants.vdbsRootRoute;
+
+  public static readonly vdbModelsRootRoute = "Models";
+  public static readonly vdbModelsRootPath = "/" + VdbsConstants.vdbModelsRootRoute;
+
+  public static readonly vdbModelSourcesRootRoute = "VdbModelSources";
+  public static readonly vdbModelSourcesRootPath = "/" + VdbsConstants.vdbModelSourcesRootRoute;
+}

--- a/src/main/ngapp/src/app/shared/loading-state.enum.ts
+++ b/src/main/ngapp/src/app/shared/loading-state.enum.ts
@@ -15,15 +15,24 @@
  * limitations under the License.
  */
 
-import { enableProdMode } from "@angular/core";
-import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
-import { AppModule } from "@app/app.module";
-import { environment } from "@environments/environment";
+/**
+ * An enumeration of loading state
+ */
+export enum LoadingState {
 
-if (environment.production) {
-  enableProdMode();
+  /**
+   * loading
+   */
+  LOADING,
+
+  /**
+   * loaded and valid
+   */
+  LOADED_VALID,
+
+  /**
+   * loaded and invalid
+   */
+  LOADED_INVALID
+
 }
-
-platformBrowserDynamic().bootstrapModule( AppModule )
-                        .then( (success) => console.log( `Bootstrap success` ) )
-                        .catch( (err) => console.error( err ) );


### PR DESCRIPTION
Updates the AddDataserviceWizard to incorporate schema selection for JDBC sources.  Ported the necessary DSB service calls
- Adds a VdbService to handle the VDB and child object creation, deployment, etc.
- Models for the various VDB objects were added to support the VdbService
- Adds an AppSettings service to handle some of the app-wide settings that are used throughout the application.
- Additions to the dataservice wizard.  Now the wizard has 3 steps (1) Name and description (2) Table selection (3) Review and creation.
- Wizard second page content area is determined by the type of connection that is selected.  Currently only supports JDBC connections.