### PR TITLE
Initial commit of export and test features

### DIFF
--- a/src/main/ngapp/locale/messages.es.xlf
+++ b/src/main/ngapp/locale/messages.es.xlf
@@ -375,8 +375,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="navHeader.beetleStudio" datatype="html">
-        <source>BeETLe Studio</source>
-        <target>BeETLE Studio</target>
+        <source>Beetle Studio</source>
+        <target>BeetlE Studio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/nav-header/nav-header.component.ts</context>
           <context context-type="linenumber">4</context>

--- a/src/main/ngapp/messages.xlf
+++ b/src/main/ngapp/messages.xlf
@@ -257,7 +257,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="navHeader.beetleStudio" datatype="html">
-        <source>BeETLe Studio</source>
+        <source>Beetle Studio</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/nav-header/nav-header.component.ts</context>
           <context context-type="linenumber">4</context>

--- a/src/main/ngapp/src/app/activities/activities.component.html
+++ b/src/main/ngapp/src/app/activities/activities.component.html
@@ -9,7 +9,7 @@
   <app-page-error [error]="pageError" *ngIf="pageError"></app-page-error>
 
   <div class="container-fluid activity-list-activities" *ngIf="!pageError">
-    <div class="row">
+    <div class="col-sm-12">
       <h2 i18n="@@activities.Activities" >Activities</h2>
     </div>
     <div class="row toolbar-pf">

--- a/src/main/ngapp/src/app/activities/add-activity/add-activity.component.html
+++ b/src/main/ngapp/src/app/activities/add-activity/add-activity.component.html
@@ -6,7 +6,7 @@
     </app-breadcrumbs>
   </div>
   <div class="container-fluid" *ngIf="!pageError">
-    <div class="row">
+    <div class="col-sm-12">
       <h2></h2>
     </div>
     <!-- Add Activity Wizard -->

--- a/src/main/ngapp/src/app/connections/add-connection/add-connection.component.html
+++ b/src/main/ngapp/src/app/connections/add-connection/add-connection.component.html
@@ -6,7 +6,7 @@
     </app-breadcrumbs>
   </div>
   <div class="container-fluid" *ngIf="!pageError">
-    <div class="row">
+    <div class="col-sm-12">
       <h2></h2>
     </div>
     <!-- Add Connection Wizard -->

--- a/src/main/ngapp/src/app/connections/connections.component.html
+++ b/src/main/ngapp/src/app/connections/connections.component.html
@@ -9,7 +9,7 @@
   <app-page-error [error]="pageError" *ngIf="pageError"></app-page-error>
 
   <div class="container-fluid connection-list-connections" *ngIf="!pageError">
-    <div class="row">
+    <div class="col-sm-12">
       <h2 i18n="@@connections.connections">Connections</h2>
     </div>
     <div class="row toolbar-pf">

--- a/src/main/ngapp/src/app/core/app-settings.service.ts
+++ b/src/main/ngapp/src/app/core/app-settings.service.ts
@@ -20,14 +20,33 @@ import { Injectable } from "@angular/core";
 @Injectable()
 export class AppSettingsService {
 
+  // ** Dont change git keys - must match Komodo rest call parameters **
+  public readonly GIT_REPO_BRANCH_KEY = "repo-branch-property";
+  public readonly GIT_REPO_AUTHOR_NAME_KEY = "author-name-property";
+  public readonly GIT_REPO_AUTHOR_EMAIL_KEY = "author-email-property";
+  public readonly GIT_REPO_USERNAME_KEY = "repo-username-property";
+  public readonly GIT_REPO_PASSWORD_KEY = "repo-password-property";
+  public readonly GIT_REPO_PATH_KEY = "repo-path-property";
+  public readonly GIT_REPO_FILE_PATH_KEY = "file-path-property";
+
   private readonly komodoRoot = "tko:komodo/tko:workspace";
 
   // TODO: temporary location for user and password
   private readonly komodoUser = "dsbUser";
   private readonly komodoUserPassword = "1demo-user1";
 
+  // Map to maintain the target git repository properties
+  private readonly gitRepoProperties: Map<string, string>;
+
   constructor() {
-    // Nothing to do
+    // TODO: The git repository properties will be picked up based on the Openshift install location
+    this.gitRepoProperties = new Map<string, string>();
+    this.gitRepoProperties.set(this.GIT_REPO_PATH_KEY, "https://github.com/GIT_USER/GIT_REPO");
+    this.gitRepoProperties.set(this.GIT_REPO_BRANCH_KEY, "master");
+    this.gitRepoProperties.set(this.GIT_REPO_USERNAME_KEY, "MY_USER");
+    this.gitRepoProperties.set(this.GIT_REPO_PASSWORD_KEY, "MY_PASS");
+    this.gitRepoProperties.set(this.GIT_REPO_AUTHOR_NAME_KEY, "MY_USER");
+    this.gitRepoProperties.set(this.GIT_REPO_AUTHOR_EMAIL_KEY, "USER@SOMEWHERE.COM");
   }
 
   /*
@@ -52,6 +71,14 @@ export class AppSettingsService {
    */
   public getKomodoUserPassword( ): string {
     return this.komodoUserPassword;
+  }
+
+  /*
+   * Get the git repository property for the supplied property key
+   * @returns {string} the git repository property
+   */
+  public getGitRepoProperty(propertyKey: string): string {
+    return this.gitRepoProperties.get(propertyKey);
   }
 
 }

--- a/src/main/ngapp/src/app/core/nav-header/nav-header.component.html
+++ b/src/main/ngapp/src/app/core/nav-header/nav-header.component.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-default navbar-pf" role="navigation">
   <div class="navbar-header">
     <a class="navbar-brand" href="" style="">
-      <div i18n="@@navHeader.beetleStudio" id="navbar-logo" class="navbar-brand-logo">BeETLe Studio</div>
+      <div i18n="@@navHeader.beetleStudio" id="navbar-logo" class="navbar-brand-logo">Beetle Studio</div>
     </a>
   </div>
   <div class="collapse navbar-collapse navbar-collapse-1">
@@ -29,7 +29,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <h1 i18n="@@navHeader.beetleStudio">BeETLe Studio</h1>
+        <h1 i18n="@@navHeader.beetleStudio">Beetle Studio</h1>
         <div class="product-versions-pf">
           <table>
             <tr>

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
@@ -44,12 +44,14 @@
           <label class="col-sm-2 control-label">Name:</label>
           <label class="col-sm-10">{{ dataserviceName }}</label>
         </div>
-        <!--
         <div class="form-group">
-          <label class="col-sm-2 control-label">Connection:</label>
-          <label class="col-sm-5">{{ connectionName }}</label>
+          <label class="col-sm-2 control-label">Description:</label>
+          <label class="col-sm-10">{{ dataserviceDescription }}</label>
         </div>
-        -->
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Source Tables:</label>
+          <label class="col-sm-5">{{ dataserviceSourceTables }}</label>
+        </div>
       </form>
     </pfng-wizard-substep>
     <!-- Step 3B: Create -->

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
@@ -332,6 +332,21 @@ export class AddDataserviceWizardComponent implements OnInit {
     return this.basicPropertyForm.controls["description"].value;
   }
 
+  /**
+   * @returns {string} the selected source table names in string form
+   */
+  public get dataserviceSourceTables(): string {
+    let tableStr = "None";
+    const tables = this.tableSelector.getSelectedTables();
+    if (tables.length > 0) {
+      tableStr = tables[0].getConnection().getId() + " [" + tables[0].getName() + "]";
+    }
+    if (tables.length === 2) {
+      tableStr = tableStr + ", " + tables[1].getConnection().getId() + " [" + tables[1].getName() + "]";
+    }
+    return tableStr;
+  }
+
   public updatePage2ValidStatus( ): void {
     this.step2Config.nextEnabled = this.tableSelector.valid();
     this.setNavAway(this.step2Config.nextEnabled);

--- a/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.html
@@ -6,7 +6,7 @@
     </app-breadcrumbs>
   </div>
   <div class="container-fluid" *ngIf="!pageError">
-    <div class="row">
+    <div class="col-sm-12">
       <h2></h2>
     </div>
     <!-- Add Dataservice Wizard -->

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
@@ -16,10 +16,12 @@
           <div>
             <span>{{ dataservice.getDescription() }}</span>
           </div>
-          <!--
           <div>
-            <span><b i18n="@@dataservicesCards.Connection" >Connection:</b>&nbsp;&nbsp;{{ dataservice.getConnection().getName() }}</span>
+            <span class="fa fa-database"></span>
+            <span *ngIf="dataservice.getServiceViewTables().length==1">{{dataservice.getServiceViewTables()[0]}}</span>
+            <span *ngIf="dataservice.getServiceViewTables().length==2">{{dataservice.getServiceViewTables()[0]}}, {{dataservice.getServiceViewTables()[1]}}</span>
           </div>
+          <!--
           <div class="dataservice-tags" *ngIf="dataservice.tags && dataservice.tags.length > 0">
             <span class="dataservice-tags-label">Tags:</span>
             <span class="dataservice-tag" *ngFor="let tag of dataservice.tags" (click)="selectTag(tag, $event)">{{ tag }}</span>

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
@@ -9,13 +9,15 @@
           <div class="list-group-item-heading">
             <a [routerLink]="[dataservice.getId()]">{{ dataservice.getId() }}</a>
           </div>
-          <!--
-          <div class="list-group-item-text">{{ dataservice.description }}</div>
-          -->
+          <div class="list-group-item-text">
+            {{ dataservice.getDescription() }}
+          </div>
         </div>
         <div class="list-view-pf-additional-info">
           <div>
-            <span>{{ dataservice.getDescription() }}</span>
+            <span class="fa fa-database"></span>
+            <span *ngIf="dataservice.getServiceViewTables().length==1">{{dataservice.getServiceViewTables()[0]}}</span>
+            <span *ngIf="dataservice.getServiceViewTables().length==2">{{dataservice.getServiceViewTables()[0]}}, {{dataservice.getServiceViewTables()[1]}}</span>
           </div>
           <!--
           <div class="dataservice-tags" *ngIf="dataservice.tags && dataservice.tags.length > 0">

--- a/src/main/ngapp/src/app/dataservices/dataservices-routing.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-routing.module.ts
@@ -21,10 +21,12 @@ import { Routes } from "@angular/router";
 import { AddDataserviceComponent } from "@dataservices/add-dataservice/add-dataservice.component";
 import { DataservicesComponent } from "@dataservices/dataservices.component";
 import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
+import { TestDataserviceComponent } from "@dataservices/test-dataservice/test-dataservice.component";
 
 const dataservicesRoutes: Routes = [
   { path: DataservicesConstants.dataservicesRootRoute, component: DataservicesComponent },
-  { path: DataservicesConstants.addDataserviceRoute, component: AddDataserviceComponent }
+  { path: DataservicesConstants.addDataserviceRoute, component: AddDataserviceComponent },
+  { path: DataservicesConstants.testDataserviceRoute, component: TestDataserviceComponent }
 ];
 
 @NgModule({

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -9,7 +9,7 @@
   <app-page-error [error]="pageError" *ngIf="pageError"></app-page-error>
 
   <div class="container-fluid dataservice-list-dataservices" *ngIf="!pageError">
-    <div class="row">
+    <div class="col-sm-12">
       <h2 i18n="@@dataservices.dataservices">Dataservices</h2>
     </div>
     <div class="row toolbar-pf">
@@ -89,6 +89,14 @@
 
       <!-- The list or card view -->
       <div class="col-md-12" *ngIf="isLoaded('dataservices')">
+        <!-- Notification for Dataservice Export -->
+        <pfng-inline-notification [header]="exportNotificationHeader"
+                                  [message]="exportNotificationMessage"
+                                  [dismissable]="true"
+                                  [type]="exportNotificationType"
+                                  [hidden]="exportNotificationHidden">
+        </pfng-inline-notification>
+
         <app-dataservices-list *ngIf="isListLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
                                (testDataservice)="onTest($event)" (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
                                (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-list>
@@ -105,3 +113,4 @@
 <app-confirm-delete (deleteSelected)="onDeleteDataservice()">
   <p i18n="@@dataservices.doYouReallyWantToDeleteSelectedDataservice" >Do you really want to delete the selected Dataservice?</p>
 </app-confirm-delete>
+

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
@@ -13,6 +13,7 @@ import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
 import { ModalModule } from "ngx-bootstrap";
+import { PatternFlyNgModule } from "patternfly-ng";
 
 describe("DataservicesComponent", () => {
   let component: DataservicesComponent;
@@ -20,7 +21,7 @@ describe("DataservicesComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ CoreModule, FormsModule, HttpModule, ModalModule.forRoot(), RouterTestingModule, SharedModule ],
+      imports: [ CoreModule, FormsModule, HttpModule, ModalModule.forRoot(), PatternFlyNgModule, RouterTestingModule, SharedModule ],
       declarations: [ DataservicesComponent, DataservicesListComponent, DataservicesCardsComponent ],
       providers: [
         { provide: VdbService, useClass: MockVdbService },

--- a/src/main/ngapp/src/app/dataservices/dataservices.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.module.ts
@@ -33,6 +33,8 @@ import { AddDataserviceWizardComponent } from "./add-dataservice-wizard/add-data
 import { AddDataserviceComponent } from "./add-dataservice/add-dataservice.component";
 import { ConnectionTableSelectorComponent } from "./connection-table-selector/connection-table-selector.component";
 import { JdbcTableSelectorComponent } from "./jdbc-table-selector/jdbc-table-selector.component";
+import { SqlControlComponent } from "./sql-control/sql-control.component";
+import { TestDataserviceComponent } from "./test-dataservice/test-dataservice.component";
 
 @NgModule({
   imports: [
@@ -52,7 +54,9 @@ import { JdbcTableSelectorComponent } from "./jdbc-table-selector/jdbc-table-sel
     AddDataserviceWizardComponent,
     AddDataserviceComponent,
     ConnectionTableSelectorComponent,
-    JdbcTableSelectorComponent
+    JdbcTableSelectorComponent,
+    TestDataserviceComponent,
+    SqlControlComponent
   ],
   providers: [
     DataserviceService,

--- a/src/main/ngapp/src/app/dataservices/shared/column-data.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/column-data.model.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The ColumnData model
+ */
+export class ColumnData {
+
+  private name: string;
+  private label: string;
+  private type: string;
+
+  /**
+   * Constructor
+   * @param {Object} json the JSON representation of ColumnData
+   */
+  constructor(json: object = {}) {
+    for (const field of Object.keys(json)) {
+      this[field] = json[field];
+    }
+  }
+
+  /**
+   * @returns {string} the column name
+   */
+  public getName( ): string {
+    return this.name;
+  }
+
+  /**
+   * @returns {string} the column label
+   */
+  public getLabel( ): string {
+    return this.label;
+  }
+
+  /**
+   * @returns {string} the column type
+   */
+  public getType( ): string {
+    return this.type;
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
@@ -24,6 +24,11 @@ export class Dataservice implements Identifiable< string > {
 
   private keng__id: string;
   private tko__description: string;
+  private serviceVdbName: string;
+  private serviceVdbVersion: string;
+  private serviceView: string;
+  private serviceViewModel: string;
+  private serviceViewTables: string[];
   private appSettings: AppSettingsService;
 
   /**
@@ -95,6 +100,41 @@ export class Dataservice implements Identifiable< string > {
   }
 
   /**
+   * @returns {string} the dataservice Vdb name (can be null)
+   */
+  public getServiceVdbName(): string {
+    return this.serviceVdbName;
+  }
+
+  /**
+   * @returns {string} the dataservice Vdb version (can be null)
+   */
+  public getServiceVdbVersion(): string {
+    return this.serviceVdbVersion;
+  }
+
+  /**
+   * @returns {string} the dataservice view name (can be null)
+   */
+  public getServiceViewName(): string {
+    return this.serviceView;
+  }
+
+  /**
+   * @returns {string} the dataservice view model name (can be null)
+   */
+  public getServiceViewModel(): string {
+    return this.serviceViewModel;
+  }
+
+  /**
+   * @returns {string} the dataservice view table names array (can be null)
+   */
+  public getServiceViewTables(): string[] {
+    return this.serviceViewTables;
+  }
+
+  /**
    * @returns {string} the dataservice dataPath (can be null)
    */
   public getDataPath(): string {
@@ -122,11 +162,51 @@ export class Dataservice implements Identifiable< string > {
     this.tko__description = description ? description : null;
   }
 
+  /**
+   * @param {string} name the dataservice service vdb name
+   */
+  public setServiceVdbName( name: string ): void {
+    this.serviceVdbName = name;
+  }
+
+  /**
+   * @param {string} version the dataservice service vdb version
+   */
+  public setServiceVdbVersion( version: string ): void {
+    this.serviceVdbVersion = version;
+  }
+
+  /**
+   * @param {string} viewName the dataservice view name
+   */
+  public setServiceViewName( viewName: string ): void {
+    this.serviceView = viewName;
+  }
+
+  /**
+   * @param {string} viewModel the dataservice view model
+   */
+  public setServiceViewModel( viewModel: string ): void {
+    this.serviceViewModel = viewModel;
+  }
+
+  /**
+   * @param {string[]} viewTables the dataservice view tables
+   */
+  public setServiceViewTables( viewTables: string[] ): void {
+    this.serviceViewTables = viewTables;
+  }
+
   // overrides toJSON - we do not want the appSettings
   public toJSON(): {} {
     return {
       keng__id: this.keng__id,
-      tko__description: this.tko__description
+      tko__description: this.tko__description,
+      serviceVdbName: this.serviceVdbName,
+      serviceVdbVersion: this.serviceVdbVersion,
+      serviceView: this.serviceView,
+      serviceViewModel: this.serviceViewModel,
+      serviceViewTables: this.serviceViewTables
     };
   }
 

--- a/src/main/ngapp/src/app/dataservices/shared/dataservices-constants.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservices-constants.ts
@@ -12,9 +12,17 @@
 
 export class DataservicesConstants {
 
+  public static readonly dataservicesExport = "export";
+
+  public static readonly dataserviceRootRoute = "dataservice";
+  public static readonly dataserviceRootPath = "/" + DataservicesConstants.dataserviceRootRoute;
+
   public static readonly dataservicesRootRoute = "dataservices";
   public static readonly dataservicesRootPath = "/" + DataservicesConstants.dataservicesRootRoute;
 
   public static readonly addDataserviceRoute = DataservicesConstants.dataservicesRootRoute + "/add-dataservice";
   public static readonly addDataservicePath = DataservicesConstants.dataservicesRootPath + "/add-dataservice";
+
+  public static readonly testDataserviceRoute = DataservicesConstants.dataservicesRootRoute + "/test-dataservice";
+  public static readonly testDataservicePath = DataservicesConstants.dataservicesRootPath + "/test-dataservice";
 }

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -40,8 +40,17 @@ export class MockDataserviceService extends DataserviceService {
   constructor( http: Http, vdbService: VdbService, appSettings: AppSettingsService, logger: LoggerService ) {
     super(http, vdbService, appSettings, logger);
     this.serv1.setId("serv1");
+    this.serv1.setServiceViewTables(["table1", "table2"]);
+    this.serv1.setServiceViewModel("viewModel");
+    this.serv1.setServiceViewName("views");
     this.serv2.setId("serv2");
+    this.serv2.setServiceViewTables(["table1", "table2"]);
+    this.serv2.setServiceViewModel("viewModel");
+    this.serv2.setServiceViewName("views");
     this.serv3.setId("serv3");
+    this.serv3.setServiceViewTables(["table1", "table2"]);
+    this.serv3.setServiceViewModel("viewModel");
+    this.serv3.setServiceViewName("views");
   }
 
   /**
@@ -68,6 +77,14 @@ export class MockDataserviceService extends DataserviceService {
    */
   public deleteDataservice(dataserviceId: string): Observable<boolean> {
     return Observable.of(true);
+  }
+
+  /**
+   * Get the current Dataservice selection
+   * @returns {Dataservice} the selected Dataservice
+   */
+  public getSelectedDataservice( ): Dataservice {
+    return this.serv1;
   }
 
 }

--- a/src/main/ngapp/src/app/dataservices/shared/query-results.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/query-results.model.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ColumnData } from "@dataservices/shared/column-data.model";
+import { RowData } from "@dataservices/shared/row-data.model";
+
+/**
+ * QueryResults model
+ */
+export class QueryResults {
+
+  private columns: ColumnData[] = [];
+  private rows: RowData[] = [];
+
+  /**
+   * Constructor
+   * @param {object} json the representation of the QueryResults
+   */
+  constructor(json: object = {}) {
+    for (const field of Object.keys(json)) {
+      if (field === "columns") {
+        const jsonColumns = json[field];
+        const cols: ColumnData[] = [];
+        for (const arr of jsonColumns) {
+          const col: ColumnData = new ColumnData(arr);
+          cols.push(col);
+        }
+        this.setColumns(cols);
+      } else if (field === "rows") {
+        const jsonRows = json[field];
+        const rows: RowData[] = [];
+        for (const arr of jsonRows) {
+          const row: RowData = new RowData(arr);
+          rows.push(row);
+        }
+        this.setRows(rows);
+      }
+    }
+  }
+
+  /**
+   * @returns {ColumnData[]} the column data
+   */
+  public getColumns(): ColumnData[] {
+    return this.columns;
+  }
+
+  /**
+   * @param {ColumnData[]} columns the column data (optional)
+   */
+  public setColumns( columns?: ColumnData[] ): void {
+    this.columns = columns ? columns : null;
+  }
+
+  /**
+   * @returns {RowData[]} the row data
+   */
+  public getRows(): RowData[] {
+    return this.rows;
+  }
+
+  /**
+   * @param {RowData[]} rows the row data (optional)
+   */
+  public setRows( rows?: RowData[] ): void {
+    this.rows = rows ? rows : null;
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/row-data.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/row-data.model.ts
@@ -15,22 +15,28 @@
  * limitations under the License.
  */
 
-import { ConnectionsConstants } from "@connections/shared/connections-constants";
+/**
+ * The RowData model
+ */
+export class RowData {
 
-export const environment = {
+  private row: string[] = [];
 
-  production: true,
+  /**
+   * Constructor
+   * @param {object} json the representation of the RowData
+   */
+  constructor(json: object = {}) {
+    for (const field of Object.keys(json)) {
+      this[field] = json[field];
+    }
+  }
 
-  // the home page path
-  homePagePath: ConnectionsConstants.connectionsRootPath,
+  /**
+   * @returns {string[]} the row data array
+   */
+  public getData( ): string[] {
+    return this.row;
+  }
 
-  // REST URL - Komodo import export url
-  komodoImportExportUrl: "https://localhost:8443/vdb-builder/v1/importexport",
-
-  // REST URL - Komodo workspace
-  komodoWorkspaceUrl: "https://localhost:8443/vdb-builder/v1/workspace",
-
-  // REST URL - Komodo teiid server
-  komodoTeiidUrl: "https://localhost:8443/vdb-builder/v1/teiid",
-
-};
+}

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.css
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.css
@@ -1,0 +1,23 @@
+
+.sql-control-control-title {
+  float: left;
+  color: grey;
+}
+.sql-control-controls-query {
+  float: right;
+  margin-bottom: 0.5em;
+}
+
+.sql-control-editor {
+  clear: both;
+  border: 1px inset grey;
+}
+
+.sql-control-controls-limit input[type=number] {
+  width: 5em;
+}
+
+.sql-control-controls-offset input[type=number] {
+  width: 5em;
+}
+

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.html
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.html
@@ -1,0 +1,36 @@
+<div class="row">
+  <div class="col-sm-4">
+    <div class="sql-control-control-title">Enter the SQL, then click Submit</div>
+    <div class="sql-control-controls-query">
+      <button class="btn btn-primary" (click)="submitCurrentQuery()">
+        <span class="fa fa-fw fa-search"></span>Submit
+      </button>
+    </div>
+
+    <div class="sql-control-editor">
+      <textarea [(ngModel)]="queryText" rows="10" cols="60" title="title"></textarea>
+    </div>
+  </div>
+
+  <div class="col-sm-8" *ngIf="queryRunning">
+    <div class="alert alert-info">
+      <span class="pficon pficon-info"></span>
+      <span class="spinner spinner-sm spinner-inline"></span>
+      <strong>Submitting the Query...</strong>
+    </div>
+  </div>
+  <div class="col-sm-8" *ngIf="queryRanInvalid">
+    <div class="alert alert-info">
+      <span class="pficon pficon-info"></span>
+      <strong>There was an error running the Query!</strong>
+    </div>
+  </div>
+  <div class="col-sm-8" *ngIf="queryRanValid">
+    <h4>Query Results</h4>
+    <h6>TODO - use a datagrid component.  Currently, just titles are shown.</h6>
+    <div class="col-sm-2" *ngFor="let column of queryResults.getColumns()">
+      {{ column.getLabel() }}
+    </div>
+  </div>
+
+</div>

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
@@ -1,0 +1,41 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { FormsModule } from "@angular/forms";
+import { HttpModule } from "@angular/http";
+import { AppSettingsService } from "@core/app-settings.service";
+import { LoggerService } from "@core/logger.service";
+import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
+import { SqlControlComponent } from "./sql-control.component";
+
+describe("SqlControlComponent", () => {
+  let component: SqlControlComponent;
+  let fixture: ComponentFixture<SqlControlComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ FormsModule, HttpModule  ],
+      declarations: [ SqlControlComponent ],
+      providers: [
+        AppSettingsService, LoggerService,
+        { provide: DataserviceService, useClass: MockDataserviceService },
+        { provide: VdbService, useClass: MockVdbService }
+      ]
+    })
+      .compileComponents().then(() => {
+      // nothing to do
+    });
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SqlControlComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should be created", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.ts
@@ -1,0 +1,155 @@
+import { Component, OnInit } from "@angular/core";
+import { LoggerService } from "@core/logger.service";
+import { ColumnData } from "@dataservices/shared/column-data.model";
+import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { QueryResults } from "@dataservices/shared/query-results.model";
+import { RowData } from "@dataservices/shared/row-data.model";
+import { LoadingState } from "@shared/loading-state.enum";
+
+@Component({
+  selector: "app-sql-control",
+  templateUrl: "./sql-control.component.html",
+  styleUrls: ["./sql-control.component.css"]
+})
+export class SqlControlComponent implements OnInit {
+
+  private dataserviceService: DataserviceService;
+  private logger: LoggerService;
+  private showResults = false;
+  private queryResultsLoading: LoadingState;
+  private queryTxt: string;
+  private queryResults: QueryResults;
+  private data: any[] = [];
+
+  constructor( dataserviceService: DataserviceService, logger: LoggerService ) {
+    this.dataserviceService = dataserviceService;
+    this.logger = logger;
+  }
+
+  public ngOnInit(): void {
+    this.queryTxt = this.getDataserviceInitialQueryText();
+  }
+
+  /*
+   * Submit the currently entered SQL
+   */
+  public submitCurrentQuery( ): void {
+    this.submitQuery(this.queryText, this.dataserviceService.getSelectedDataservice().getId(), 15, 0);
+  }
+
+  /*
+   * Determines if the results table should be shown
+   */
+  public get showResultsTable( ): boolean {
+    return this.showResults;
+  }
+
+  /**
+   * Get the SQL text
+   */
+  public get queryText( ): string {
+    return this.queryTxt;
+  }
+
+  /**
+   * Set the SQL text
+   */
+  public set queryText( sql: string ) {
+    this.queryTxt = sql;
+  }
+
+  /**
+   * Determine if query is running
+   */
+  public get queryRunning( ): boolean {
+    return ( this.queryResultsLoading != null && (this.queryResultsLoading === LoadingState.LOADING) );
+  }
+
+  /**
+   * Determine if query has run successfully
+   */
+  public get queryRanValid( ): boolean {
+    return ( this.queryResultsLoading != null && (this.queryResultsLoading === LoadingState.LOADED_VALID) );
+  }
+
+  /**
+   * Determine if query has run but was not successful
+   */
+  public get queryRanInvalid( ): boolean {
+    return ( this.queryResultsLoading != null && (this.queryResultsLoading === LoadingState.LOADED_INVALID) );
+  }
+
+  /*
+  * the selected data service query text
+  */
+  private getDataserviceInitialQueryText(): string {
+    const dataservice = this.dataserviceService.getSelectedDataservice();
+    const modelName = dataservice.getServiceViewModel();
+    const serviceView = dataservice.getServiceViewName();
+
+    if ( !modelName || !serviceView ) {
+      return "SELECT * FROM ";
+    }
+
+    return "SELECT * FROM " + modelName + "." + serviceView + ";";
+  }
+
+  /*
+   * Submits the query
+   */
+  private submitQuery(sqlQuery: string, dataserviceName: string, limit: number, offset: number): void {
+    this.queryResultsLoading = LoadingState.LOADING;
+    this.queryResults = null;
+    const self = this;
+    this.dataserviceService
+      .queryDataservice(sqlQuery, dataserviceName, limit, offset)
+      .subscribe(
+        (queryResult) => {
+          self.refreshData(queryResult);
+          self.queryResultsLoading = LoadingState.LOADED_VALID;
+        },
+        (error) => {
+          self.logger.error("[SqlControlComponent] Error getting query results: %o", error);
+          self.queryResultsLoading = LoadingState.LOADED_INVALID;
+        }
+      );
+  }
+
+  /*
+   * Refresh the Query results
+   * @param {QueryResults} results the results for a query
+   */
+  private refreshData(results: QueryResults): void {
+    this.queryResults = results;
+    if (!results) {
+      return;
+    }
+
+    const columns: ColumnData[] = results.getColumns();
+    const rows: RowData[] = results.getRows();
+
+    //
+    // Get the column titles
+    //
+    const columnTitles = [];
+    for ( const column of columns ) {
+      const colLabel: string = column.getLabel();
+      columnTitles.push(colLabel);
+    }
+
+    //
+    // Define the row data
+    //
+    this.data = [];
+    let rowData;
+    for ( const row of rows ) {
+      rowData = row.getData();
+      const dataRow = {};
+      for (let i = 0; i < rowData.length; i++) {
+        dataRow[columnTitles[i]] = rowData[i];
+      }
+      this.data.push(dataRow);
+    }
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.html
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.html
@@ -1,0 +1,30 @@
+<div style="margin-left: 150px">
+  <div id="dataservices-breadcrumb-bar">
+    <app-breadcrumbs>
+      <li i18n="@@testDataservice.dataservices" app-breadcrumb label="Dataservices" icon="table" [route]="[ dataservicesLink ]"></li>
+      <li i18n="@@testDataservice.testDataservice" app-breadcrumb label="Test Dataservice" icon="play" class="active"></li>
+    </app-breadcrumbs>
+  </div>
+  <div class="container-fluid" *ngIf="!pageError">
+    <div class="col-sm-12">
+      <h2>Test Dataservice '<strong>{{ this.dataservice.getId() }}</strong>'</h2>
+    </div>
+    <!-- Test Dataservice Controls -->
+    <div class="col-sm-10" *ngIf="pageLoading">
+      <div class="alert alert-info">
+        <span class="pficon pficon-info"></span>
+        <span class="spinner spinner-sm spinner-inline"></span>
+        <strong>Deploying the Dataservice...</strong>
+      </div>
+    </div>
+    <div class="col-sm-10" *ngIf="pageLoadedInvalid">
+      <div class="alert alert-info">
+        <span class="pficon pficon-info"></span>
+        <strong>There was an error deploying the Dataservice!</strong>
+      </div>
+    </div>
+    <div class="col-sm-10" *ngIf="pageLoadedValid">
+      <app-sql-control></app-sql-control>
+    </div>
+  </div>
+</div>

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
@@ -1,0 +1,40 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { FormsModule } from "@angular/forms";
+import { RouterTestingModule } from "@angular/router/testing";
+import { CoreModule } from "@core/core.module";
+import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
+import { SqlControlComponent } from "@dataservices/sql-control/sql-control.component";
+import { TestDataserviceComponent } from "./test-dataservice.component";
+
+describe("TestDataserviceComponent", () => {
+  let component: TestDataserviceComponent;
+  let fixture: ComponentFixture<TestDataserviceComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ CoreModule, FormsModule, RouterTestingModule ],
+      declarations: [ SqlControlComponent, TestDataserviceComponent ],
+      providers: [
+        { provide: DataserviceService, useClass: MockDataserviceService },
+        { provide: VdbService, useClass: MockVdbService }
+      ]
+    })
+      .compileComponents().then(() => {
+      // nothing to do
+    });
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestDataserviceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should be created", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.ts
@@ -1,0 +1,73 @@
+import { Component } from "@angular/core";
+import { Router } from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
+import { LoggerService } from "@core/logger.service";
+import { Dataservice } from "@dataservices/shared/dataservice.model";
+import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
+import { AbstractPageComponent } from "@shared/abstract-page.component";
+import { LoadingState } from "@shared/loading-state.enum";
+
+@Component({
+  selector: "app-test-dataservice",
+  templateUrl: "./test-dataservice.component.html",
+  styleUrls: ["./test-dataservice.component.css"]
+})
+export class TestDataserviceComponent extends AbstractPageComponent {
+
+  public readonly dataservicesLink = DataservicesConstants.dataservicesRootPath;
+
+  public pageError: any = "";
+
+  private dataservice: Dataservice;
+  private dataserviceService: DataserviceService;
+  private pageLoadingState: LoadingState = LoadingState.LOADING;
+
+  constructor( router: Router, route: ActivatedRoute, dataserviceService: DataserviceService, logger: LoggerService ) {
+    super(route, logger);
+    this.dataserviceService = dataserviceService;
+  }
+
+  public loadAsyncPageData(): void {
+    this.pageLoadingState = LoadingState.LOADING;
+    this.dataservice = this.dataserviceService.getSelectedDataservice();
+
+    if (this.dataservice) {
+      const self = this;
+      // The dataservice deployment waits for the service to deploy.
+      this.dataserviceService
+        .deployDataservice(this.dataservice.getId())
+        .subscribe(
+          (wasSuccess) => {
+            this.pageLoadingState = LoadingState.LOADED_VALID;
+          },
+          (error) => {
+            this.pageLoadingState = LoadingState.LOADED_INVALID;
+            self.error(error, "Error deploying the dataservice");
+          }
+        );
+    }
+  }
+
+  /**
+   * Determine if page is loading
+   */
+  public get pageLoading( ): boolean {
+    return this.pageLoadingState === LoadingState.LOADING;
+  }
+
+  /**
+   * Determine if page has loaded successfully
+   */
+  public get pageLoadedValid( ): boolean {
+    return this.pageLoadingState === LoadingState.LOADED_VALID;
+  }
+
+  /**
+   * Determine if page has loaded but was not successful
+   */
+  public get pageLoadedInvalid( ): boolean {
+    return this.pageLoadingState === LoadingState.LOADED_INVALID;
+  }
+
+}

--- a/src/main/ngapp/src/app/shared/confirm-delete/confirm-delete.component.html
+++ b/src/main/ngapp/src/app/shared/confirm-delete/confirm-delete.component.html
@@ -3,7 +3,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" aria-hidden="true" (click)="cancel()">
+        <button type="button" class="close" aria-hidden="true" (click)="onCancelSelected()">
           <span class="pficon pficon-close"></span>
         </button>
         <h4 i18n="@@confirmDelete.confirmDelete" class="modal-title" id="confirmDeleteModalLabel">Confirm Delete</h4>

--- a/src/main/ngapp/src/environments/environment.ts
+++ b/src/main/ngapp/src/environments/environment.ts
@@ -27,6 +27,9 @@ export const environment = {
   // the home page path
   homePagePath: ConnectionsConstants.connectionsRootPath,
 
+  // REST URL - Komodo import export url
+  komodoImportExportUrl: "https://localhost:8443/vdb-builder/v1/importexport",
+
   // REST URL - Komodo workspace
   komodoWorkspaceUrl: "https://localhost:8443/vdb-builder/v1/workspace",
 


### PR DESCRIPTION
Initial commit of the dataservice export and test dataservice features.
- Renamed BeETLe to Beetle to remove ETL emphasis
- Improvements to dataservice card and list display to show the source(s)
- Added git repository export settings to AppSettingsService.  In the future these will presumably be set based on the users openshift installation.
- Hooked up dataservice export capability to komodo, passing in the AppSettingsService information for the export.
- Hooked up the dataservice 'test' capability so that the dataservice is deployed and can be tested.
- A simple test page was developed, but needs additional work (gridtable for display,etc)
