### PR TITLE
Improvements to service deployment

### DIFF
--- a/src/main/ngapp/src/app/connections/connections.component.ts
+++ b/src/main/ngapp/src/app/connections/connections.component.ts
@@ -20,6 +20,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { Connection } from "@connections/shared/connection.model";
 import { ConnectionService } from "@connections/shared/connection.service";
 import { ConnectionsConstants } from "@connections/shared/connections-constants";
+import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { ArrayUtils } from "@core/utils/array-utils";
 import { AbstractPageComponent } from "@shared/abstract-page.component";
@@ -43,6 +44,7 @@ export class ConnectionsComponent extends AbstractPageComponent {
   private selectedConns: Connection[] = [];
   private connectionNameForDelete: string;
   private router: Router;
+  private appSettingsService: AppSettingsService;
   private connectionService: ConnectionService;
   private filter: IdFilter = new IdFilter();
   private layout: LayoutType = LayoutType.CARD;
@@ -50,9 +52,11 @@ export class ConnectionsComponent extends AbstractPageComponent {
 
   @ViewChild(ConfirmDeleteComponent) private confirmDeleteDialog: ConfirmDeleteComponent;
 
-  constructor(router: Router, route: ActivatedRoute, connectionService: ConnectionService, logger: LoggerService) {
+  constructor(router: Router, route: ActivatedRoute, appSettingsService: AppSettingsService,
+              connectionService: ConnectionService, logger: LoggerService) {
     super(route, logger);
     this.router = router;
+    this.appSettingsService = appSettingsService;
     this.connectionService = connectionService;
   }
 
@@ -77,14 +81,14 @@ export class ConnectionsComponent extends AbstractPageComponent {
    * @returns {boolean} true if connections are being represented by cards
    */
   public get isCardLayout(): boolean {
-    return this.layout === LayoutType.CARD;
+    return this.appSettingsService.connectionsPageLayout === LayoutType.CARD;
   }
 
   /**
    * @returns {boolean} true if connections are being represented by items in a list
    */
   public get isListLayout(): boolean {
-    return this.layout === LayoutType.LIST;
+    return this.appSettingsService.connectionsPageLayout === LayoutType.LIST;
   }
 
   /**
@@ -174,11 +178,11 @@ export class ConnectionsComponent extends AbstractPageComponent {
   }
 
   public setListLayout(): void {
-    this.layout = LayoutType.LIST;
+    this.appSettingsService.connectionsPageLayout = LayoutType.LIST;
   }
 
   public setCardLayout(): void {
-    this.layout = LayoutType.CARD;
+    this.appSettingsService.connectionsPageLayout = LayoutType.CARD;
   }
 
   /**

--- a/src/main/ngapp/src/app/core/app-settings.service.ts
+++ b/src/main/ngapp/src/app/core/app-settings.service.ts
@@ -16,6 +16,7 @@
  */
 
 import { Injectable } from "@angular/core";
+import { LayoutType } from "@shared/layout-type.enum";
 
 @Injectable()
 export class AppSettingsService {
@@ -37,6 +38,10 @@ export class AppSettingsService {
 
   // Map to maintain the target git repository properties
   private readonly gitRepoProperties: Map<string, string>;
+
+  // page layouts
+  private svcPageLayout: LayoutType = LayoutType.CARD;
+  private connPageLayout: LayoutType = LayoutType.CARD;
 
   constructor() {
     // TODO: The git repository properties will be picked up based on the Openshift install location
@@ -79,6 +84,38 @@ export class AppSettingsService {
    */
   public getGitRepoProperty(propertyKey: string): string {
     return this.gitRepoProperties.get(propertyKey);
+  }
+
+  /*
+   * Get the LayoutType for the connections summary page
+   * @returns {LayoutType} the connections page layout
+   */
+  public get connectionsPageLayout( ): LayoutType {
+    return this.connPageLayout;
+  }
+
+  /*
+   * Sets the LayoutType for the connections summary page
+   * @param {LayoutType} layout the connections page layout
+   */
+  public set connectionsPageLayout( layout: LayoutType ) {
+    this.connPageLayout = layout;
+  }
+
+  /*
+   * Get the LayoutType for the dataservices summary page
+   * @returns {LayoutType} the dataservices page layout
+   */
+  public get dataservicesPageLayout( ): LayoutType {
+    return this.svcPageLayout;
+  }
+
+  /*
+   * Sets the LayoutType for the dataservices summary page
+   * @param {LayoutType} layout the dataservices page layout
+   */
+  public set dataservicesPageLayout( layout: LayoutType ) {
+    this.svcPageLayout = layout;
   }
 
 }

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
@@ -68,7 +68,7 @@
           <div class="wizard-pf-success-icon"><span class="glyphicon glyphicon-ok-circle"></span></div>
           <h3 class="blank-slate-pf-main-action">Creation was successful</h3>
           <p class="blank-slate-pf-secondary-action">The dataservice was created successfully. Click on the button to see all dataservices.</p>
-          <a class="btn btn-lg btn-primary" [routerLink]="[dataserviceSummaryLink]">View All Dataservices</a>
+          <button class="btn btn-lg btn-primary" type="button" (click)="onDeployDataservice()">View All Dataservices</button>
         </div>
         <!-- Create Failed -->
         <div class="wizard-pf-complete blank-slate-pf" *ngIf="createComplete && !createSuccessful">

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
@@ -241,6 +241,9 @@ export class AddDataserviceWizardComponent implements OnInit {
 
     const sourceVdbName = this.tableSelector.getSelectedTables()[0].getConnection().getId() + VdbsConstants.SOURCE_VDB_SUFFIX;
 
+    this.step3bConfig.nextEnabled = false;
+    this.step3bConfig.previousEnabled = false;
+
     // Before polling, subscribe to get status event
     this.deploymentChangeSubscription = this.vdbService.deploymentStatus.subscribe((status) => {
       this.onSourceVdbDeploymentStateChanged(status);
@@ -258,6 +261,7 @@ export class AddDataserviceWizardComponent implements OnInit {
             self.createComplete = true;
             self.createSuccessful = false;
             self.step3bConfig.nextEnabled = false;
+            self.step3bConfig.previousEnabled = true;
             self.vdbService.deploymentStatus.unsubscribe();
           }
         },
@@ -266,9 +270,30 @@ export class AddDataserviceWizardComponent implements OnInit {
           self.createComplete = true;
           self.createSuccessful = false;
           self.step3bConfig.nextEnabled = false;
+          self.step3bConfig.previousEnabled = true;
           self.vdbService.deploymentStatus.unsubscribe();
         }
       );
+  }
+
+  public onDeployDataservice(): void {
+    // Start the deployment and then redirect to the dataservice summary page
+    this.dataserviceService
+      .deployDataservice(this.dataserviceName)
+      .subscribe(
+        (wasSuccess) => {
+          // Nothing to do
+        },
+        (error) => {
+          // Nothing to do
+        }
+      );
+
+    const link: string[] = [ DataservicesConstants.dataservicesRootPath ];
+    this.logger.log("[AddDataserviceWizardComponent] Navigating to: %o", link);
+    this.router.navigate(link).then(() => {
+      // nothing to do
+    });
   }
 
   /*
@@ -296,6 +321,7 @@ export class AddDataserviceWizardComponent implements OnInit {
           this.createComplete = true;
           this.createSuccessful = false;
           this.step3bConfig.nextEnabled = false;
+          this.step3bConfig.previousEnabled = true;
         }
       }
     }
@@ -400,10 +426,12 @@ export class AddDataserviceWizardComponent implements OnInit {
             self.createComplete = true;
             self.createSuccessful = true;
             self.step3bConfig.nextEnabled = false;
+            this.step3bConfig.previousEnabled = true;
           } else {
             self.createComplete = true;
             self.createSuccessful = false;
             self.step3bConfig.nextEnabled = false;
+            this.step3bConfig.previousEnabled = true;
           }
         },
         (error) => {
@@ -411,6 +439,7 @@ export class AddDataserviceWizardComponent implements OnInit {
           self.createComplete = true;
           self.createSuccessful = false;
           self.step3bConfig.nextEnabled = false;
+          this.step3bConfig.previousEnabled = true;
         }
       );
 

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.css
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.css
@@ -9,6 +9,12 @@
 
 .dataservice-card-action-icon {
   cursor: pointer;
+  margin-left: 7px;
+}
+
+.dataservice-card-action-disabled-icon {
+  color: lightgray;
+  margin-left: 7px;
 }
 
 .dataservice-card-icon {

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
@@ -6,11 +6,20 @@
         <div class="card-pf-body">
           <!-- title -->
           <h2 class="dataservice-card-title">
-            <span class="fa fa-fw fa-table dataservice-card-icon"></span>
+            <span class="pull-left pficon-ok" *ngIf="dataservice.serviceDeploymentActive"></span>
+            <span class="pull-left pficon-error-circle-o" *ngIf="dataservice.serviceDeploymentFailed"></span>
+            <span class="pull-left pficon-warning-triangle-o" *ngIf="dataservice.serviceDeploymentInactive"></span>
+            <span class="pull-left pficon-unknown" *ngIf="dataservice.serviceDeploymentNotDeployed"></span>
+            <span class="pull-left fa fa-spinner fa-pulse" *ngIf="dataservice.serviceDeploymentLoading"></span>
+            <span class="pull-left fa fa-refresh dataservice-card-action-icon" (click)="onActivateDataservice(dataservice.getId())"></span>
+            <span class="fa fa-table dataservice-card-icon"></span>
             <span><a [routerLink]="[dataservice.getId()]">{{ dataservice.getId() }}</a></span>
-            <span class="pull-right fa fa-fw fa-close dataservice-card-action-icon" style="color:darkred;" (click)="onDeleteDataservice(dataservice.getId())"></span>
-            <span class="pull-right fa fa-fw fa-arrow-up dataservice-card-action-icon" (click)="onPublishDataservice(dataservice.getId())"></span>
-            <span class="pull-right fa fa-fw fa-play dataservice-card-action-icon" style="color:darkgreen;" (click)="onTestDataservice(dataservice.getId())"></span>
+            <span *ngIf="!dataservice.serviceDeploymentLoading" class="pull-right pficon-delete dataservice-card-action-icon" style="color:darkred;" (click)="onDeleteDataservice(dataservice.getId())"></span>
+            <span *ngIf="dataservice.serviceDeploymentLoading" class="pull-right pficon-delete dataservice-card-action-disabled-icon"></span>
+            <span *ngIf="!dataservice.serviceDeploymentLoading" class="pull-right pficon-export dataservice-card-action-icon" (click)="onPublishDataservice(dataservice.getId())"></span>
+            <span *ngIf="dataservice.serviceDeploymentLoading" class="pull-right pficon-export dataservice-card-action-disabled-icon"></span>
+            <span *ngIf="dataservice.serviceDeploymentActive" class="pull-right fa fa-list-alt dataservice-card-action-icon" (click)="onTestDataservice(dataservice.getId())"></span>
+            <span *ngIf="!dataservice.serviceDeploymentActive" class="pull-right fa fa-list-alt dataservice-card-action-disabled-icon"></span>
           </h2>
           <hr/>
           <div>

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
@@ -31,6 +31,7 @@ export class DataservicesCardsComponent {
   @Output() public dataserviceSelected: EventEmitter<Dataservice> = new EventEmitter<Dataservice>();
   @Output() public dataserviceDeselected: EventEmitter<Dataservice> = new EventEmitter<Dataservice>();
   @Output() public tagSelected: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public activateDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public testDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public publishDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteDataservice: EventEmitter<string> = new EventEmitter<string>();
@@ -52,6 +53,10 @@ export class DataservicesCardsComponent {
 
   public isSelected(dataservice: Dataservice): boolean {
     return this.selectedDataservices.indexOf(dataservice) !== -1;
+  }
+
+  public onActivateDataservice(dataserviceName: string): void {
+    this.activateDataservice.emit(dataserviceName);
   }
 
   public onTestDataservice(dataserviceName: string): void {

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.css
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.css
@@ -1,3 +1,8 @@
+.dataservice-list-state-icon {
+  margin-right: 7px;
+  font-size: 1.7em;
+}
+
 .list-view-pf-main-info {
   padding-bottom: 5px;
   padding-top: 5px;

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
@@ -2,6 +2,11 @@
   <div class="list-group-item list-view-pf-stacked" *ngFor="let dataservice of dataservices" [class.active]="isSelected(dataservice)" (click)="toggleDataserviceSelected(dataservice)">
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
+        <span class="pull-left pficon-ok dataservice-list-state-icon" *ngIf="dataservice.serviceDeploymentActive"></span>
+        <span class="pull-left pficon-error-circle-o dataservice-list-state-icon" *ngIf="dataservice.serviceDeploymentFailed"></span>
+        <span class="pull-left pficon-warning-triangle-o dataservice-list-state-icon" *ngIf="dataservice.serviceDeploymentInactive"></span>
+        <span class="pull-left pficon-unknown dataservice-list-state-icon" *ngIf="dataservice.serviceDeploymentNotDeployed"></span>
+        <span class="pull-left fa fa-spinner fa-pulse dataservice-list-state-icon" *ngIf="dataservice.serviceDeploymentLoading"></span>
         <span class="fa fa-table list-view-pf-icon-sm"></span>
       </div>
       <div class="list-view-pf-body">
@@ -28,9 +33,14 @@
         </div>
       </div>
       <div class="list-view-pf-actions">
-        <button i18n="@@dataservicesList.test" class="btn btn-default" type="button" (click)="onTestDataservice(dataservice.getId())">Test</button>
-        <button i18n="@@dataservicesList.publish" class="btn btn-default" type="button" (click)="onPublishDataservice(dataservice.getId())">Publish</button>
-        <button i18n="@@dataservicesList.delete" class="btn btn-danger" type="button" (click)="onDeleteDataservice(dataservice.getId())">Delete</button>
+        <button i18n="@@dataservicesList.activate" class="btn btn-default" type="button"
+                (click)="onActivateDataservice(dataservice.getId())">Activate</button>
+        <button i18n="@@dataservicesList.test" class="btn btn-default" type="button"
+                (click)="onTestDataservice(dataservice.getId())" [disabled]="!dataservice.serviceDeploymentActive">Test</button>
+        <button i18n="@@dataservicesList.publish" class="btn btn-default" type="button"
+                (click)="onPublishDataservice(dataservice.getId())" [disabled]="dataservice.serviceDeploymentLoading">Publish</button>
+        <button i18n="@@dataservicesList.delete" class="btn btn-danger" type="button"
+                (click)="onDeleteDataservice(dataservice.getId())" [disabled]="dataservice.serviceDeploymentLoading">Delete</button>
       </div>
     </div>
   </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
@@ -32,6 +32,7 @@ export class DataservicesListComponent {
   @Output() public dataserviceSelected: EventEmitter<Dataservice> = new EventEmitter<Dataservice>();
   @Output() public dataserviceDeselected: EventEmitter<Dataservice> = new EventEmitter<Dataservice>();
   @Output() public tagSelected: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public activateDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public testDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public publishDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteDataservice: EventEmitter<string> = new EventEmitter<string>();
@@ -55,6 +56,10 @@ export class DataservicesListComponent {
 
   public isSelected(dataservice: Dataservice): boolean {
     return this.selectedDataservices.indexOf(dataservice) !== -1;
+  }
+
+  public onActivateDataservice(dataserviceName: string): void {
+    this.activateDataservice.emit(dataserviceName);
   }
 
   public onTestDataservice(dataserviceName: string): void {

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -98,10 +98,12 @@
         </pfng-inline-notification>
 
         <app-dataservices-list *ngIf="isListLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
-                               (testDataservice)="onTest($event)" (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
+                               (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
+                               (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
                                (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-list>
         <app-dataservices-cards *ngIf="isCardLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
-                                (testDataservice)="onTest($event)" (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
+                                (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
+                                (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
                                 (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-cards>
       </div>
 

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
@@ -3,6 +3,7 @@ import { FormsModule } from "@angular/forms";
 import { HttpModule } from "@angular/http";
 import { By } from "@angular/platform-browser";
 import { RouterTestingModule } from "@angular/router/testing";
+import { AppSettingsService } from "@core/app-settings.service";
 import { CoreModule } from "@core/core.module";
 import { DataservicesCardsComponent } from "@dataservices/dataservices-cards/dataservices-cards.component";
 import { DataservicesListComponent } from "@dataservices/dataservices-list/dataservices-list.component";
@@ -24,7 +25,8 @@ describe("DataservicesComponent", () => {
       imports: [ CoreModule, FormsModule, HttpModule, ModalModule.forRoot(), PatternFlyNgModule, RouterTestingModule, SharedModule ],
       declarations: [ DataservicesComponent, DataservicesListComponent, DataservicesCardsComponent ],
       providers: [
-        { provide: VdbService, useClass: MockVdbService },
+        AppSettingsService,
+        { provide: VdbService, useClass: MockVdbService }
       ]
     });
 

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
@@ -17,6 +17,7 @@
 
 import { ReflectiveInjector } from "@angular/core";
 import { AppSettingsService } from "@core/app-settings.service";
+import { DeploymentState } from "@dataservices/shared/deployment-state.enum";
 import { Identifiable } from "@shared/identifiable";
 import { SortDirection } from "@shared/sort-direction.enum";
 
@@ -29,6 +30,7 @@ export class Dataservice implements Identifiable< string > {
   private serviceView: string;
   private serviceViewModel: string;
   private serviceViewTables: string[];
+  private deploymentState: DeploymentState = DeploymentState.LOADING;
   private appSettings: AppSettingsService;
 
   /**
@@ -149,6 +151,53 @@ export class Dataservice implements Identifiable< string > {
   }
 
   /**
+   * @returns {DeploymentState} the dataservice Deployment state
+   */
+  public getServiceDeploymentState(): DeploymentState {
+    return this.deploymentState;
+  }
+
+  /**
+   * Accessor to determine if service deployment is active
+   * @returns {boolean} the dataservice service deployment active state
+   */
+  public get serviceDeploymentActive(): boolean {
+    return this.deploymentState === DeploymentState.ACTIVE;
+  }
+
+  /**
+   * Accessor to determine if service deployment is inactive
+   * @returns {boolean} the dataservice service deployment inactive state
+   */
+  public get serviceDeploymentInactive(): boolean {
+    return this.deploymentState === DeploymentState.INACTIVE;
+  }
+
+  /**
+   * Accessor to determine if service deployment is loading
+   * @returns {boolean} the dataservice service deployment loading state
+   */
+  public get serviceDeploymentLoading(): boolean {
+    return this.deploymentState === DeploymentState.LOADING;
+  }
+
+  /**
+   * Accessor to determine if service deployment is failed
+   * @returns {boolean} the dataservice service deployment failed state
+   */
+  public get serviceDeploymentFailed(): boolean {
+    return this.deploymentState === DeploymentState.FAILED;
+  }
+
+  /**
+   * Accessor to determine if service is not deployed
+   * @returns {boolean} the dataservice service not deployed state
+   */
+  public get serviceDeploymentNotDeployed(): boolean {
+    return this.deploymentState === DeploymentState.NOT_DEPLOYED;
+  }
+
+  /**
    * @param {string} id the dataservice identifier (optional)
    */
   public setId( id?: string ): void {
@@ -195,6 +244,13 @@ export class Dataservice implements Identifiable< string > {
    */
   public setServiceViewTables( viewTables: string[] ): void {
     this.serviceViewTables = viewTables;
+  }
+
+  /**
+   * @param {DeploymentState} state the dataservice deployment state
+   */
+  public setServiceDeploymentState( state: DeploymentState ): void {
+    this.deploymentState = state;
   }
 
   // overrides toJSON - we do not want the appSettings

--- a/src/main/ngapp/src/app/dataservices/shared/deployment-state.enum.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/deployment-state.enum.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An enumeration of Deployment state
+ */
+export enum DeploymentState {
+
+  /**
+   * loading
+   */
+  LOADING,
+
+  /**
+   * active
+   */
+  ACTIVE,
+
+  /**
+   * inactive
+   */
+  INACTIVE,
+
+  /**
+   * failed
+   */
+  FAILED,
+
+  /**
+   * not deployed
+   */
+  NOT_DEPLOYED
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -87,4 +87,19 @@ export class MockDataserviceService extends DataserviceService {
     return this.serv1;
   }
 
+  /**
+   * Updates the current Dataservice states - triggers update to be broadcast to interested components
+   */
+  public updateDataserviceStates(): void {
+    // Nothing to do
+  }
+
+  /**
+   * Polls the server and sends Dataservice state updates at the specified interval
+   * @param {number} pollIntervalSec the interval (sec) between polling attempts
+   */
+  public pollDataserviceStatus(pollIntervalSec: number): void {
+    // Nothing to do
+  }
+
 }

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.ts
@@ -21,7 +21,7 @@ export class TestDataserviceComponent extends AbstractPageComponent {
 
   private dataservice: Dataservice;
   private dataserviceService: DataserviceService;
-  private pageLoadingState: LoadingState = LoadingState.LOADING;
+  private pageLoadingState: LoadingState = LoadingState.LOADED_VALID;
 
   constructor( router: Router, route: ActivatedRoute, dataserviceService: DataserviceService, logger: LoggerService ) {
     super(route, logger);
@@ -29,24 +29,7 @@ export class TestDataserviceComponent extends AbstractPageComponent {
   }
 
   public loadAsyncPageData(): void {
-    this.pageLoadingState = LoadingState.LOADING;
     this.dataservice = this.dataserviceService.getSelectedDataservice();
-
-    if (this.dataservice) {
-      const self = this;
-      // The dataservice deployment waits for the service to deploy.
-      this.dataserviceService
-        .deployDataservice(this.dataservice.getId())
-        .subscribe(
-          (wasSuccess) => {
-            this.pageLoadingState = LoadingState.LOADED_VALID;
-          },
-          (error) => {
-            this.pageLoadingState = LoadingState.LOADED_INVALID;
-            self.error(error, "Error deploying the dataservice");
-          }
-        );
-    }
   }
 
   /**


### PR DESCRIPTION
Dataservices are now being deployed when a dataservice is created.  'test dataservice' is disabled until the dataservice is deployed and active.  This improves the user experience since the user no longer needs to wait for the service to deploy when testing the service.  
- The service card layout icons were modified.  Now includes a 'status' to show whether the dataservice is active.  A 'refresh' button is included next to it - to allow the user to redeploy the service.
- Improved the remaining icons for test, export and delete.  These actions are disabled while the service is being deployed.
- When a dataservice is deleted, it's corresponding serviceVdb is also undeployed.
- DataserviceService now polls for dataservice DeploymentState updates and broadcasts to interested components.  Currently, the dataservice summary component responds to these updates in order to update the service states. 
- Added the card / list layout selections to AppSettingsService for the Dataservice and Connection pages.  Now the pages maintain selected layout if user changes page, then comes back.
- Minor change to the AddDataserviceWizard so that previous and next buttons are disabled during dataservice creation.  