### PR TITLE
Add data grid component for query results

### DIFF
--- a/src/main/ngapp/package-lock.json
+++ b/src/main/ngapp/package-lock.json
@@ -12,7 +12,7 @@
       "requires": {
         "loader-utils": "1.1.0",
         "source-map": "0.5.7",
-        "typescript": "2.3.4"
+        "typescript": "2.6.2"
       }
     },
     "@angular/animations": {
@@ -84,7 +84,7 @@
         "stylus": "0.54.5",
         "stylus-loader": "3.0.1",
         "temp": "0.8.3",
-        "typescript": "2.3.4",
+        "typescript": "2.4.2",
         "url-loader": "0.5.9",
         "walk-sync": "0.3.2",
         "webpack": "3.4.1",
@@ -92,6 +92,14 @@
         "webpack-dev-server": "2.5.1",
         "webpack-merge": "4.1.0",
         "zone.js": "0.8.18"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+          "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+          "dev": true
+        }
       }
     },
     "@angular/common": {
@@ -216,6 +224,11 @@
         "source-map": "0.5.7"
       }
     },
+    "@swimlane/ngx-datatable": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-datatable/-/ngx-datatable-11.1.5.tgz",
+      "integrity": "sha512-BRRHMrgw9tG0BezTnfszzFTlpW9B9Zh5kyZF/pxqfJxpUsZ0aA/uXlL4cloe4+msQ6yIdu1/jhUCDInwSzmpFw=="
+    },
     "@types/jasmine": {
       "version": "2.5.54",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.54.tgz",
@@ -232,9 +245,9 @@
       }
     },
     "@types/node": {
-      "version": "6.0.90",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
-      "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA=="
+      "version": "6.0.92",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
+      "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw=="
     },
     "@types/q": {
       "version": "0.0.32",
@@ -6545,7 +6558,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
       "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
       "requires": {
-        "@types/node": "6.0.90"
+        "@types/node": "6.0.92"
       }
     },
     "parsejson": {
@@ -6638,9 +6651,9 @@
       }
     },
     "patternfly": {
-      "version": "3.29.9",
-      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.29.9.tgz",
-      "integrity": "sha1-HNS16+pmhFJ/Cgeamve3TDmCf7w=",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.30.1.tgz",
+      "integrity": "sha1-/1ZmPQsbd3g5rfDn2aSznW7kTCY=",
       "requires": {
         "bootstrap": "3.3.7",
         "bootstrap-datepicker": "1.6.4",
@@ -6860,7 +6873,7 @@
         "core-js": "2.4.1",
         "moment": "2.17.1",
         "ngx-bootstrap": "1.8.0",
-        "patternfly": "3.29.9",
+        "patternfly": "3.30.1",
         "rxjs": "5.5.2",
         "zone.js": "0.8.4"
       },
@@ -7737,7 +7750,7 @@
       "integrity": "sha1-myIXQXCaTGLVzVPGqt1UpxE36V8=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.90",
+        "@types/node": "6.0.92",
         "@types/q": "0.0.32",
         "@types/selenium-webdriver": "2.53.42",
         "blocking-proxy": "0.0.5",
@@ -9585,9 +9598,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "uglify-js": {

--- a/src/main/ngapp/package.json
+++ b/src/main/ngapp/package.json
@@ -21,9 +21,10 @@
     "@angular/platform-browser": "^4.4.6",
     "@angular/platform-browser-dynamic": "^4.4.6",
     "@angular/router": "^4.4.6",
+    "@swimlane/ngx-datatable": "^11.1.5",
     "core-js": "^2.4.1",
     "ngx-bootstrap": "^1.9.3",
-    "patternfly": "^3.29.9",
+    "patternfly": "^3.30.1",
     "patternfly-ng": "^0.13.7",
     "rxjs": "^5.5.2",
     "zone.js": "^0.8.14"
@@ -34,7 +35,7 @@
     "@angular/language-service": "^4.4.6",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
-    "@types/node": "^6.0.90",
+    "@types/node": "^6.0.92",
     "codelyzer": "~3.1.1",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
@@ -49,6 +50,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.7.0",
-    "typescript": "~2.3.3"
+    "typescript": "~2.6.2"
   }
 }

--- a/src/main/ngapp/src/app/dataservices/dataservices.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.module.ts
@@ -28,6 +28,7 @@ import { DataservicesComponent } from "@dataservices/dataservices.component";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
+import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 import { PatternFlyNgModule } from "patternfly-ng";
 import { AddDataserviceWizardComponent } from "./add-dataservice-wizard/add-dataservice-wizard.component";
 import { AddDataserviceComponent } from "./add-dataservice/add-dataservice.component";
@@ -43,6 +44,7 @@ import { TestDataserviceComponent } from "./test-dataservice/test-dataservice.co
     CoreModule,
     SharedModule,
     FormsModule,
+    NgxDatatableModule,
     ReactiveFormsModule,
     RouterModule,
     PatternFlyNgModule

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.css
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.css
@@ -1,3 +1,6 @@
+@import '~@swimlane/ngx-datatable/release/index.css';
+@import '~@swimlane/ngx-datatable/release/themes/material.css';
+@import '~@swimlane/ngx-datatable/release/assets/icons.css';
 
 .sql-control-control-title {
   float: left;
@@ -20,4 +23,3 @@
 .sql-control-controls-offset input[type=number] {
   width: 5em;
 }
-

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.html
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.html
@@ -1,36 +1,40 @@
 <div class="row">
-  <div class="col-sm-4">
+  <div class="col-sm-12">
     <div class="sql-control-control-title">Enter the SQL, then click Submit</div>
-    <div class="sql-control-controls-query">
-      <button class="btn btn-primary" (click)="submitCurrentQuery()">
-        <span class="fa fa-fw fa-search"></span>Submit
-      </button>
-    </div>
 
-    <div class="sql-control-editor">
-      <textarea [(ngModel)]="queryText" rows="10" cols="60" title="title"></textarea>
+    <div class="col-sm-12 sql-control-editor">
+      <textarea [(ngModel)]="queryText" rows="10" cols="120" title="title"></textarea>
+      <div class="sql-control-controls-query">
+        <button class="btn btn-primary" (click)="submitCurrentQuery()">
+          <span class="fa fa-fw fa-search"></span>Submit
+        </button>
+      </div>
     </div>
   </div>
 
-  <div class="col-sm-8" *ngIf="queryRunning">
+  <div class="col-sm-12" *ngIf="queryRunning">
     <div class="alert alert-info">
       <span class="pficon pficon-info"></span>
       <span class="spinner spinner-sm spinner-inline"></span>
       <strong>Submitting the Query...</strong>
     </div>
   </div>
-  <div class="col-sm-8" *ngIf="queryRanInvalid">
+  <div class="col-sm-12" *ngIf="queryRanInvalid">
     <div class="alert alert-info">
       <span class="pficon pficon-info"></span>
       <strong>There was an error running the Query!</strong>
     </div>
   </div>
-  <div class="col-sm-8" *ngIf="queryRanValid">
+  <div class="col-sm-12" *ngIf="queryRanValid">
     <h4>Query Results</h4>
-    <h6>TODO - use a datagrid component.  Currently, just titles are shown.</h6>
-    <div class="col-sm-2" *ngFor="let column of queryResults.getColumns()">
-      {{ column.getLabel() }}
-    </div>
+    <ngx-datatable [rows]="rows"
+                   [columns]="columns"
+                   [scrollbarV]="true"
+                   [scrollbarH]="true"
+                   [columnMode]="'force'"
+                   [reorderable]="true"
+                   [cssClasses]='customClasses'>
+    </ngx-datatable>
   </div>
 
 </div>

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
@@ -9,6 +9,7 @@ import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.se
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SqlControlComponent } from "./sql-control.component";
+import { NgxDatatableModule } from "@swimlane/ngx-datatable";
 
 describe("SqlControlComponent", () => {
   let component: SqlControlComponent;
@@ -16,7 +17,7 @@ describe("SqlControlComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ FormsModule, HttpModule  ],
+      imports: [ FormsModule, HttpModule, NgxDatatableModule  ],
       declarations: [ SqlControlComponent ],
       providers: [
         AppSettingsService, LoggerService,

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.ts
@@ -19,7 +19,18 @@ export class SqlControlComponent implements OnInit {
   private queryResultsLoading: LoadingState;
   private queryTxt: string;
   private queryResults: QueryResults;
-  private data: any[] = [];
+
+  public columns: any[] = [];
+  public rows: any[] = [];
+
+  public customClasses = {
+    sortAscending: 'fa fa-sort-asc',
+    sortDescending: 'fa fa-sort-desc',
+    pagerLeftArrow: 'fa fa-chevron-left',
+    pagerRightArrow: 'fa fa-chevron-right',
+    pagerPrevious: 'fa fa-step-backward',
+    pagerNext: 'fa fa-step-forward'
+  };
 
   constructor( dataserviceService: DataserviceService, logger: LoggerService ) {
     this.dataserviceService = dataserviceService;
@@ -125,30 +136,76 @@ export class SqlControlComponent implements OnInit {
       return;
     }
 
-    const columns: ColumnData[] = results.getColumns();
-    const rows: RowData[] = results.getRows();
-
-    //
-    // Get the column titles
-    //
-    const columnTitles = [];
-    for ( const column of columns ) {
-      const colLabel: string = column.getLabel();
-      columnTitles.push(colLabel);
-    }
+    const columnData: ColumnData[] = results.getColumns();
+    const rowData: RowData[] = results.getRows();
 
     //
     // Define the row data
     //
-    this.data = [];
-    let rowData;
-    for ( const row of rows ) {
-      rowData = row.getData();
-      const dataRow = {};
-      for (let i = 0; i < rowData.length; i++) {
-        dataRow[columnTitles[i]] = rowData[i];
+    let firstTime = true;
+    const rowNumHeader = "ROW #";
+    // const widths: Map< string, number > = new Map< string, number >();
+
+    for ( let rowIndex = 0; rowIndex < rowData.length; rowIndex++ ) {
+      const row = rowData[ rowIndex ];
+      const data = row.getData();
+
+      let dataRow = {};
+      dataRow[ rowNumHeader ] = rowIndex + 1;
+
+      for (let colIndex = 0; colIndex < data.length; colIndex++) {
+        const label = columnData[ colIndex ].getLabel();
+        dataRow[ label ] = data[ colIndex ];
+
+        // size column to largest width data of first 50 rows
+        // if ( rowIndex < 50 ) {
+        //   const value = "" + dataRow[ label ];
+        //   const width = value.length;
+        //   const labelWidth = label.length
+        //
+        //   if ( firstTime ) {
+        //     const max = Math.max( width, labelWidth );
+        //     widths.set( label, max );
+        //   } else {
+        //     const currVal: number = widths.get( label );
+        //     const max = Math.max( width, currVal, labelWidth );
+        //     widths.set( label, max );
+        //   }
+        // }
       }
-      this.data.push(dataRow);
+
+      this.rows.push( dataRow );
+      firstTime = false;
+    }
+
+    // setup row number column
+    const column = { canAutoResize: true,
+                     draggable: false,
+                     // flexGrow: rowNumHeader.length,
+                     maxWidth: 50,
+                     minWidth: 50,
+                     name: rowNumHeader,
+                     prop: rowNumHeader,
+                     resizable: true,
+                     sortable: true,
+                     width: 50 };
+    this.columns.push( column );
+
+    //
+    // Setup columns
+    //
+    for ( let i = 0; i < columnData.length; i++) {
+      const colData = columnData[ i ];
+      const label = colData.getLabel();
+      // const width = widths.get( label );
+      const column = { canAutoResize: true,
+                       draggable: false,
+                       // flexGrow: width,
+                       name: label.toUpperCase(),
+                       prop: label,
+                       resizable: true,
+                       sortable: true };
+      this.columns.push( column );
     }
   }
 

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
@@ -8,7 +8,8 @@ import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.se
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SqlControlComponent } from "@dataservices/sql-control/sql-control.component";
-import { TestDataserviceComponent } from "./test-dataservice.component";
+import { TestDataserviceComponent } from "@dataservices/test-dataservice/test-dataservice.component";
+import { NgxDatatableModule } from "@swimlane/ngx-datatable";
 
 describe("TestDataserviceComponent", () => {
   let component: TestDataserviceComponent;
@@ -16,7 +17,7 @@ describe("TestDataserviceComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ CoreModule, FormsModule, RouterTestingModule ],
+      imports: [ CoreModule, FormsModule, RouterTestingModule, NgxDatatableModule ],
       declarations: [ SqlControlComponent, TestDataserviceComponent ],
       providers: [
         { provide: DataserviceService, useClass: MockDataserviceService },

--- a/src/main/ngapp/src/styles.css
+++ b/src/main/ngapp/src/styles.css
@@ -1,1 +1,42 @@
 /* You can add global styles to this file, and also import other style files */
+
+.ngx-datatable {
+  position: absolute; top:0;left:0;right:0;bottom:0;
+}
+
+.datatable-header {
+  color: white;
+  background-color: #cccccc;
+  text-align: center;
+}
+
+.datatable-header-cell {
+  vertical-align: bottom;
+  border-bottom: 2px solid #ddd;
+  padding: 8px;
+  line-height: 1.42857143;
+  font-weight: bold;
+  color: rgb(51, 51, 51);
+}
+
+.datatable-body-row {
+  border-bottom: 1px solid #d8d8d8;
+}
+
+.datatable-row-even {
+  background-color: white;
+}
+
+.datatable-row-odd {
+  background-color: #f2f2f2;
+}
+
+.datatable-body-cell {
+  padding: 0.25em;
+  border-left: 1px solid #d8d8d8;
+  border-right: 1px solid #d8d8d8;
+}
+
+.datatable-body-cell:first-child {
+  text-align: center;
+}


### PR DESCRIPTION
- now using ngx-datatable for query results
- ngx-datatable is planned to be added to the PatternFly Angular 2+ library in the near future
- upgraded TypeScript to 2.6.2 so that ngx-datatable could be used
- started modifying the dataservice test page by orientating the query results below the query editor