### PR TITLE
Addition of QuickLook on Dataservice summary page

### DIFF
--- a/src/main/ngapp/src/app/connections/connections-cards/connections-cards.component.html
+++ b/src/main/ngapp/src/app/connections/connections-cards/connections-cards.component.html
@@ -8,7 +8,7 @@
           <h2 class="connection-card-title">
             <span class="fa fa-fw fa-plug connection-card-icon"></span>
             <span><a [routerLink]="[connection.getId()]">{{ connection.getId() }}</a></span>
-            <span class="pull-right fa fa-fw fa-close connection-card-action-icon" style="color:darkred;" (click)="onDeleteConnection(connection.getId())"></span>
+            <span class="pull-right pficon-delete connection-card-action-icon" style="color:darkred;" (click)="onDeleteConnection(connection.getId())"></span>
           </h2>
           <hr/>
           <div>

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.css
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.css
@@ -9,12 +9,12 @@
 
 .dataservice-card-action-icon {
   cursor: pointer;
-  margin-left: 7px;
+  margin-left: 10px;
 }
 
 .dataservice-card-action-disabled-icon {
   color: lightgray;
-  margin-left: 7px;
+  margin-left: 10px;
 }
 
 .dataservice-card-icon {

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
@@ -22,6 +22,9 @@
             <span *ngIf="!dataservice.serviceDeploymentActive" class="pull-right fa fa-list-alt dataservice-card-action-disabled-icon"></span>
           </h2>
           <hr/>
+          <div class="pull-right">
+            <span class="pull-right fa fa-search dataservice-card-action-icon" (click)="onQuickLookDataservice(dataservice.getId())"></span>
+          </div>
           <div>
             <span>{{ dataservice.getDescription() }}</span>
           </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
@@ -35,6 +35,7 @@ export class DataservicesCardsComponent {
   @Output() public testDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public publishDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteDataservice: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public quickLookDataservice: EventEmitter<string> = new EventEmitter<string>();
 
   /**
    * Constructor.
@@ -69,6 +70,10 @@ export class DataservicesCardsComponent {
 
   public onDeleteDataservice(dataserviceName: string): void {
     this.deleteDataservice.emit(dataserviceName);
+  }
+
+  public onQuickLookDataservice(dataserviceName: string): void {
+    this.quickLookDataservice.emit(dataserviceName);
   }
 
   public onSelectTag(tag: string, event: MouseEvent): void {

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.css
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.css
@@ -3,6 +3,12 @@
   font-size: 1.7em;
 }
 
+.dataservice-list-quicklook-icon {
+  margin-left: 20px;
+  font-size: 1.3em;
+  cursor: pointer;
+}
+
 .list-view-pf-main-info {
   padding-bottom: 5px;
   padding-top: 5px;

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
@@ -24,6 +24,9 @@
             <span *ngIf="dataservice.getServiceViewTables().length==1">{{dataservice.getServiceViewTables()[0]}}</span>
             <span *ngIf="dataservice.getServiceViewTables().length==2">{{dataservice.getServiceViewTables()[0]}}, {{dataservice.getServiceViewTables()[1]}}</span>
           </div>
+          <div>
+            <span class="fa fa-search dataservice-list-quicklook-icon" (click)="onQuickLookDataservice(dataservice.getId())"></span>
+          </div>
           <!--
           <div class="dataservice-tags" *ngIf="dataservice.tags && dataservice.tags.length > 0">
             <span class="dataservice-tags-label">Tags:</span>

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
@@ -36,6 +36,7 @@ export class DataservicesListComponent {
   @Output() public testDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public publishDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteDataservice: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public quickLookDataservice: EventEmitter<string> = new EventEmitter<string>();
 
   private router: Router;
 
@@ -72,6 +73,10 @@ export class DataservicesListComponent {
 
   public onDeleteDataservice(dataserviceName: string): void {
     this.deleteDataservice.emit(dataserviceName);
+  }
+
+  public onQuickLookDataservice(dataserviceName: string): void {
+    this.quickLookDataservice.emit(dataserviceName);
   }
 
   // public onSelectTag(tag: string, event: MouseEvent): void {

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.css
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.css
@@ -55,3 +55,43 @@ a.clear-filters {
 .dataservice-list-items .none-matched-state .alert {
   background-color: white;
 }
+
+.dataservice-summary-top-area-with-results {
+  height: 20vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.dataservice-summary-bottom-area-with-results {
+  height: 50vh;
+}
+
+.dataservice-summary-top-area-no-results {
+}
+
+.dataservice-summary-bottom-area-no-results {
+}
+
+.dataservice-results-hr {
+  height: 3px;
+  border: none;
+  color: darkgray;
+  background-color: darkgray;
+}
+
+.dataservice-results-action-icon-close {
+  cursor: pointer;
+  color: darkred;
+  font-size: 1.5em;
+}
+
+.dataservice-results-action-icon-refresh {
+  cursor: pointer;
+  font-size: 1.5em;
+  margin-left: 10px;
+}
+
+.dataservice-results-action-icon {
+  cursor: pointer;
+  font-size: 1.5em;
+}

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -90,23 +90,35 @@
       <!-- The list or card view -->
       <div class="col-md-12" *ngIf="isLoaded('dataservices')">
         <!-- Notification for Dataservice Export -->
-        <pfng-inline-notification [header]="exportNotificationHeader"
-                                  [message]="exportNotificationMessage"
-                                  [dismissable]="true"
-                                  [type]="exportNotificationType"
-                                  [hidden]="exportNotificationHidden">
-        </pfng-inline-notification>
+        <pfng-toast-notification *ngIf="showExportNotification" [header]="exportNotificationHeader"
+                                 [message]="exportNotificationMessage"
+                                 [type]="exportNotificationType"
+                                 [showClose]="true"
+                                 (onCloseSelect)="onCloseExportNotification()">
+        </pfng-toast-notification>
 
-        <app-dataservices-list *ngIf="isListLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
-                               (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
-                               (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
-                               (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-list>
-        <app-dataservices-cards *ngIf="isCardLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
-                                (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
-                                (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
-                                (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-cards>
+        <div class="{{cardListAreaCss}}">
+          <app-dataservices-list *ngIf="isListLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
+                                 (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
+                                 (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
+                                 (quickLookDataservice)="onQuickLook($event)"
+                                 (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-list>
+          <app-dataservices-cards *ngIf="isCardLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
+                                  (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
+                                  (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
+                                  (quickLookDataservice)="onQuickLook($event)"
+                                  (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-cards>
+        </div>
       </div>
-
+      <div class="col-md-12 {{resultsAreaCss}}" *ngIf="showResults">
+        <hr class="dataservice-results-hr">
+        <span class="pull-left fa fa-list-alt dataservice-results-action-icon" (click)="onTest(quickLookServiceName)"></span>
+        <span class="pull-left fa fa-refresh dataservice-results-action-icon-refresh" (click)="onSubmitQuickLookQuery()"></span>
+        <span class="pull-right fa fa-fw fa-close dataservice-results-action-icon-close" (click)="setQuickLookPanelOpenState(false)"></span>
+        <h3 style="margin-left: 75px">Quick Look Results for Dataservice &apos;<strong>{{ quickLookServiceName }}</strong>&apos;</h3>
+        <br>
+        <app-sql-control [editorVisible]="editorVisible" ></app-sql-control>
+      </div>
     </div>
 
   </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
@@ -12,7 +12,10 @@ import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
+import { SqlControlComponent } from "@dataservices/sql-control/sql-control.component";
 import { SharedModule } from "@shared/shared.module";
+import { NgxDatatableModule } from "@swimlane/ngx-datatable";
+import { CodemirrorModule } from "ng2-codemirror";
 import { ModalModule } from "ngx-bootstrap";
 import { PatternFlyNgModule } from "patternfly-ng";
 
@@ -22,8 +25,9 @@ describe("DataservicesComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ CoreModule, FormsModule, HttpModule, ModalModule.forRoot(), PatternFlyNgModule, RouterTestingModule, SharedModule ],
-      declarations: [ DataservicesComponent, DataservicesListComponent, DataservicesCardsComponent ],
+      imports: [ CoreModule, FormsModule, HttpModule, ModalModule.forRoot(), PatternFlyNgModule,
+                 RouterTestingModule, SharedModule, CodemirrorModule, NgxDatatableModule ],
+      declarations: [ DataservicesComponent, DataservicesListComponent, DataservicesCardsComponent, SqlControlComponent ],
       providers: [
         AppSettingsService,
         { provide: VdbService, useClass: MockVdbService }

--- a/src/main/ngapp/src/app/dataservices/dataservices.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.module.ts
@@ -28,7 +28,7 @@ import { DataservicesComponent } from "@dataservices/dataservices.component";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
-import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+import { NgxDatatableModule } from "@swimlane/ngx-datatable";
 import { CodemirrorModule } from "ng2-codemirror";
 import { PatternFlyNgModule } from "patternfly-ng";
 import { AddDataserviceWizardComponent } from "./add-dataservice-wizard/add-dataservice-wizard.component";

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.html
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-sm-12">
+  <div class="col-sm-12" *ngIf="editorVisible">
     <div class="sql-control-control-title">Query Editor</div>
 
     <div class="col-sm-12 sql-control-editor">

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
@@ -8,9 +8,9 @@ import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
-import { SqlControlComponent } from "./sql-control.component";
 import { NgxDatatableModule } from "@swimlane/ngx-datatable";
 import { CodemirrorModule } from "ng2-codemirror";
+import { SqlControlComponent } from "./sql-control.component";
 
 describe("SqlControlComponent", () => {
   let component: SqlControlComponent;

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.ts
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-import 'codemirror/mode/sql/sql.js';
-import 'codemirror/addon/display/placeholder.js';
-import 'codemirror/addon/selection/active-line.js';
+import { Input } from "@angular/core";
 import { Component, OnInit } from "@angular/core";
 import { LoggerService } from "@core/logger.service";
 import { ColumnData } from "@dataservices/shared/column-data.model";
@@ -25,6 +23,9 @@ import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { QueryResults } from "@dataservices/shared/query-results.model";
 import { RowData } from "@dataservices/shared/row-data.model";
 import { LoadingState } from "@shared/loading-state.enum";
+import "codemirror/addon/display/placeholder.js";
+import "codemirror/addon/selection/active-line.js";
+import "codemirror/mode/sql/sql.js";
 
 @Component({
   selector: "app-sql-control",
@@ -33,12 +34,7 @@ import { LoadingState } from "@shared/loading-state.enum";
 })
 export class SqlControlComponent implements OnInit {
 
-  private dataserviceService: DataserviceService;
-  private logger: LoggerService;
-  private showResults = false;
-  private queryResultsLoading: LoadingState;
-  private queryTxt: string;
-  private queryResults: QueryResults;
+  @Input() public editorVisible = true;
 
   public columns: any[] = [];
   public rows: any[] = [];
@@ -52,13 +48,20 @@ export class SqlControlComponent implements OnInit {
     theme: "mdn-like" };
 
   public customClasses = {
-    sortAscending: 'fa fa-sort-asc',
-    sortDescending: 'fa fa-sort-desc',
-    pagerLeftArrow: 'fa fa-chevron-left',
-    pagerRightArrow: 'fa fa-chevron-right',
-    pagerPrevious: 'fa fa-step-backward',
-    pagerNext: 'fa fa-step-forward'
+    sortAscending: "fa fa-sort-asc",
+    sortDescending: "fa fa-sort-desc",
+    pagerLeftArrow: "fa fa-chevron-left",
+    pagerRightArrow: "fa fa-chevron-right",
+    pagerPrevious: "fa fa-step-backward",
+    pagerNext: "fa fa-step-forward"
   };
+
+  private dataserviceService: DataserviceService;
+  private logger: LoggerService;
+  private showResults = false;
+  private queryResultsLoading: LoadingState;
+  private queryTxt: string;
+  private queryResults: QueryResults;
 
   constructor( dataserviceService: DataserviceService, logger: LoggerService ) {
     this.dataserviceService = dataserviceService;
@@ -66,6 +69,14 @@ export class SqlControlComponent implements OnInit {
   }
 
   public ngOnInit(): void {
+    this.initQueryText();
+    this.submitCurrentQuery();
+  }
+
+  /*
+   * Initialize the query text based on the selected dataservice
+   */
+  public initQueryText( ): void {
     this.queryTxt = this.getDataserviceInitialQueryText();
   }
 
@@ -181,7 +192,7 @@ export class SqlControlComponent implements OnInit {
       const row = rowData[ rowIndex ];
       const data = row.getData();
 
-      let dataRow = {};
+      const dataRow = {};
       dataRow[ rowNumHeader ] = rowIndex + 1;
 
       for (let colIndex = 0; colIndex < data.length; colIndex++) {


### PR DESCRIPTION
Adds quick look panel for dataservice results summary at the bottom of the dataservice summary page.
- adds 'magnifying glass' icon on the dataservice card and list to open quicklook.
- modifies sqlControl component to add 'editorVisible' property.  This allows users of the component to hide the sqlEditor area if desired.
- dataservicesComponent was modified to add the results panel and corresponding logic to display and hide
- also changed the inline notification for publishing.  Changed it to a toast notification.  There were issues with the inline notification (was not able to redisplay once dismissed).  The toast notification is a better solution.
- other minor formatting fixes.