### PR TITLE
Adds notifier service for dataservice feature

### DIFF
--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.spec.ts
@@ -10,6 +10,7 @@ import { JdbcTableSelectorComponent } from "@dataservices/jdbc-table-selector/jd
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { PropertyFormPropertyComponent } from "@shared/property-form/property-form-property/property-form-property.component";
 import { PropertyFormComponent } from "@shared/property-form/property-form.component";
@@ -26,6 +27,7 @@ describe("AddDataserviceWizardComponent", () => {
       declarations: [ AddDataserviceWizardComponent, ConnectionTableSelectorComponent, JdbcTableSelectorComponent,
                       PropertyFormComponent, PropertyFormPropertyComponent ],
       providers: [
+        NotifierService,
         { provide: DataserviceService, useClass: MockDataserviceService },
         { provide: ConnectionService, useClass: MockConnectionService },
         { provide: VdbService, useClass: MockVdbService },

--- a/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.spec.ts
@@ -11,6 +11,7 @@ import { JdbcTableSelectorComponent } from "@dataservices/jdbc-table-selector/jd
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
 import { PatternFlyNgModule } from "patternfly-ng";
@@ -26,6 +27,7 @@ describe("AddDataserviceComponent", () => {
       declarations: [ AddDataserviceComponent, AddDataserviceWizardComponent,
                       ConnectionTableSelectorComponent, JdbcTableSelectorComponent ],
       providers: [
+        NotifierService,
         { provide: DataserviceService, useClass: MockDataserviceService },
         { provide: ConnectionService, useClass: MockConnectionService },
         { provide: VdbService, useClass: MockVdbService }

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
@@ -11,6 +11,7 @@ import { DataservicesComponent } from "@dataservices/dataservices.component";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SqlControlComponent } from "@dataservices/sql-control/sql-control.component";
 import { SharedModule } from "@shared/shared.module";
@@ -30,6 +31,7 @@ describe("DataservicesComponent", () => {
       declarations: [ DataservicesComponent, DataservicesListComponent, DataservicesCardsComponent, SqlControlComponent ],
       providers: [
         AppSettingsService,
+        NotifierService,
         { provide: VdbService, useClass: MockVdbService }
       ]
     });

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.ts
@@ -24,6 +24,7 @@ import { Dataservice } from "@dataservices/shared/dataservice.model";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
 import { DeploymentState } from "@dataservices/shared/deployment-state.enum";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SqlControlComponent } from "@dataservices/sql-control/sql-control.component";
 import { AbstractPageComponent } from "@shared/abstract-page.component";
@@ -67,19 +68,22 @@ export class DataservicesComponent extends AbstractPageComponent {
   private exportNotificationType = NotificationType.SUCCESS;
   private exportNotificationVisible = false;
   private dataserviceStateSubscription: Subscription;
+  private notifierService: NotifierService;
 
   @ViewChild(ConfirmDeleteComponent) private confirmDeleteDialog: ConfirmDeleteComponent;
   @ViewChild(SqlControlComponent) private sqlControlComponent: SqlControlComponent;
 
   constructor(router: Router, route: ActivatedRoute, dataserviceService: DataserviceService,
-              logger: LoggerService, appSettingsService: AppSettingsService, vdbService: VdbService ) {
+              logger: LoggerService, appSettingsService: AppSettingsService,
+              notifierService: NotifierService, vdbService: VdbService ) {
     super(route, logger);
     this.router = router;
     this.appSettingsService = appSettingsService;
     this.dataserviceService = dataserviceService;
     this.vdbService = vdbService;
+    this.notifierService = notifierService;
     // Register for dataservice state changes
-    this.dataserviceStateSubscription = this.dataserviceService.dataserviceStateChange.subscribe((serviceStateMap) => {
+    this.dataserviceStateSubscription = this.notifierService.getDataserviceStateMap().subscribe((serviceStateMap) => {
       this.onDataserviceStateChanged(serviceStateMap);
     });
   }

--- a/src/main/ngapp/src/app/dataservices/dataservices.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.module.ts
@@ -26,6 +26,7 @@ import { DataservicesListComponent } from "@dataservices/dataservices-list/datas
 import { DataservicesRoutingModule } from "@dataservices/dataservices-routing.module";
 import { DataservicesComponent } from "@dataservices/dataservices.component";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
 import { NgxDatatableModule } from "@swimlane/ngx-datatable";
@@ -65,7 +66,8 @@ import { TestDataserviceComponent } from "./test-dataservice/test-dataservice.co
   providers: [
     DataserviceService,
     VdbService,
-    LoggerService
+    LoggerService,
+    NotifierService
   ],
   exports: [
   ]

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.spec.ts
@@ -4,13 +4,18 @@ import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 
 describe("DataserviceService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpModule ],
-      providers: [DataserviceService, AppSettingsService, LoggerService,
+      providers: [
+        DataserviceService,
+        AppSettingsService,
+        LoggerService,
+        NotifierService,
         { provide: VdbService, useClass: MockVdbService }
       ]
     });

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -22,6 +22,7 @@ import { LoggerService } from "@core/logger.service";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { NewDataservice } from "@dataservices/shared/new-dataservice.model";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import "rxjs/add/observable/of";
 import "rxjs/add/observable/throw";
@@ -37,8 +38,9 @@ export class MockDataserviceService extends DataserviceService {
   private serv3 = new Dataservice();
   private services: Dataservice[] = [this.serv1, this.serv2, this.serv3];
 
-  constructor( http: Http, vdbService: VdbService, appSettings: AppSettingsService, logger: LoggerService ) {
-    super(http, vdbService, appSettings, logger);
+  constructor(http: Http, vdbService: VdbService, appSettings: AppSettingsService,
+              notifierService: NotifierService, logger: LoggerService ) {
+    super(http, vdbService, appSettings, notifierService, logger);
     this.serv1.setId("serv1");
     this.serv1.setServiceViewTables(["table1", "table2"]);
     this.serv1.setServiceViewModel("viewModel");

--- a/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
@@ -19,6 +19,7 @@ import { Injectable } from "@angular/core";
 import { Http } from "@angular/http";
 import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { Table } from "@dataservices/shared/table.model";
 import { VdbModelSource } from "@dataservices/shared/vdb-model-source.model";
 import { VdbModel } from "@dataservices/shared/vdb-model.model";
@@ -44,8 +45,8 @@ export class MockVdbService extends VdbService {
   private vdbStatus3 = new VdbStatus();
   private statuses: VdbStatus[] = [this.vdbStatus1, this.vdbStatus3, this.vdbStatus3];
 
-  constructor( http: Http, appSettings: AppSettingsService, logger: LoggerService ) {
-    super(http, appSettings, logger);
+  constructor(http: Http, appSettings: AppSettingsService, notifierService: NotifierService, logger: LoggerService ) {
+    super(http, appSettings, notifierService, logger);
     this.vdb1.setId("serv1");
     this.vdb2.setId("serv2");
     this.vdb3.setId("serv3");

--- a/src/main/ngapp/src/app/dataservices/shared/notifier.service.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/notifier.service.spec.ts
@@ -1,0 +1,15 @@
+import { inject, TestBed } from "@angular/core/testing";
+
+import { NotifierService } from "./notifier.service";
+
+describe("NotifierService", () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [NotifierService]
+    });
+  });
+
+  it("should be created", inject([NotifierService], (service: NotifierService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/main/ngapp/src/app/dataservices/shared/notifier.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/notifier.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from "@angular/core";
+import { DeploymentState } from "@dataservices/shared/deployment-state.enum";
+import { VdbStatus } from "@dataservices/shared/vdb-status.model";
+import { Observable } from "rxjs/Observable";
+import { ReplaySubject } from "rxjs/ReplaySubject";
+import { Subject } from "rxjs/Subject";
+
+/**
+ * NotifierService is used to send notifications to any interested components, and for interested components to register
+ * for notifications
+ */
+@Injectable()
+export class NotifierService {
+
+  private deploymentStatusSubject: Subject<VdbStatus> = new ReplaySubject<VdbStatus>(1);
+  private dataserviceStateSubject: Subject< Map<string, DeploymentState> > = new ReplaySubject< Map<string, DeploymentState> >(1);
+
+  constructor() {
+    // Nothing to do
+  }
+
+  /**
+   * Sends VdbStatus
+   * @param {VdbStatus} status the VDB deployment Status
+   */
+  public sendVdbDeploymentStatus(status: VdbStatus): void {
+    this.deploymentStatusSubject.next(status);
+  }
+
+  /**
+   * Get the VdbStatus Observable
+   * @returns {Observable<VdbStatus>}
+   */
+  public getVdbDeploymentStatus(): Observable<VdbStatus> {
+    return this.deploymentStatusSubject.asObservable();
+  }
+
+  /**
+   * Clears VdbStatus
+   */
+  public clearVdbDeploymentStatus(): void {
+    this.deploymentStatusSubject.next(null);
+  }
+
+  /**
+   * Sends map of dataservice DeploymentState
+   * @param {Map<string, DeploymentState>} stateMap
+   */
+  public sendDataserviceStateMap(stateMap: Map<string, DeploymentState>): void {
+    this.dataserviceStateSubject.next(stateMap);
+  }
+
+  /**
+   * Get the map of dataservice DeploymentState
+   * @returns {Observable<Map<string, DeploymentState>>}
+   */
+  public getDataserviceStateMap(): Observable<Map<string, DeploymentState>> {
+    return this.dataserviceStateSubject.asObservable();
+  }
+
+  /**
+   * Clears the dataservice DeploymentState
+   */
+  public clearDataserviceStateMap(): void {
+    this.dataserviceStateSubject.next(null);
+  }
+}

--- a/src/main/ngapp/src/app/dataservices/shared/vdb.service.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb.service.spec.ts
@@ -2,13 +2,19 @@ import { inject, TestBed } from "@angular/core/testing";
 import { HttpModule } from "@angular/http";
 import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 
 describe("VdbService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpModule ],
-      providers: [VdbService, AppSettingsService, LoggerService]
+      providers: [
+        VdbService,
+        AppSettingsService,
+        NotifierService,
+        LoggerService
+      ]
     });
   });
 

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
@@ -7,6 +7,7 @@ import { LoggerService } from "@core/logger.service";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { NgxDatatableModule } from "@swimlane/ngx-datatable";
 import { CodemirrorModule } from "ng2-codemirror";
@@ -21,7 +22,9 @@ describe("SqlControlComponent", () => {
       imports: [ FormsModule, HttpModule, NgxDatatableModule, CodemirrorModule  ],
       declarations: [ SqlControlComponent ],
       providers: [
-        AppSettingsService, LoggerService,
+        AppSettingsService,
+        LoggerService,
+        NotifierService,
         { provide: DataserviceService, useClass: MockDataserviceService },
         { provide: VdbService, useClass: MockVdbService }
       ]

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
@@ -6,6 +6,7 @@ import { CoreModule } from "@core/core.module";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { SqlControlComponent } from "@dataservices/sql-control/sql-control.component";
 import { TestDataserviceComponent } from "@dataservices/test-dataservice/test-dataservice.component";
@@ -21,6 +22,7 @@ describe("TestDataserviceComponent", () => {
       imports: [ CoreModule, FormsModule, RouterTestingModule, NgxDatatableModule, CodemirrorModule ],
       declarations: [ SqlControlComponent, TestDataserviceComponent ],
       providers: [
+        NotifierService,
         { provide: DataserviceService, useClass: MockDataserviceService },
         { provide: VdbService, useClass: MockVdbService }
       ]

--- a/src/main/ngapp/src/index.html
+++ b/src/main/ngapp/src/index.html
@@ -7,9 +7,6 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.28.3/css/patternfly.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.28.3/css/patternfly-additions.min.css">
 </head>
 <body>
   <app-root></app-root>

--- a/src/main/ngapp/src/styles.css
+++ b/src/main/ngapp/src/styles.css
@@ -2,6 +2,8 @@
 
 @import "~codemirror/lib/codemirror.css";
 @import "~codemirror/theme/mdn-like.css";
+@import "~patternfly/dist/css/patternfly.css";
+@import "~patternfly/dist/css/patternfly-additions.css";
 
 .CodeMirror {
   height: 200px;


### PR DESCRIPTION
Adds NotifierService for the dataservices feature.  The NotifierService is intended to be a service for sending and receiving information between components.
- adds NotifierService and moves the current vdbstatus and dataservice status notifications into it.
- rework the related components to now utilize the service to send and receive notifications
- mods to AddDataserviceWizardComponent to subscribe in initialization and unsubscribe on destroy of the component, and to better handle the incoming notification
- moved patternfly css references from index.html into styles.css