### PR TITLE
Reorg of the AddDataservice Wizard

### DIFF
--- a/src/main/ngapp/src/app/activities/activities-cards/activities-cards.component.spec.ts
+++ b/src/main/ngapp/src/app/activities/activities-cards/activities-cards.component.spec.ts
@@ -23,6 +23,7 @@ describe("ActivitiesCardsComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [ActivitiesCardsComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/activities/activities-list/activities-list.component.spec.ts
+++ b/src/main/ngapp/src/app/activities/activities-list/activities-list.component.spec.ts
@@ -23,6 +23,7 @@ describe("ActivitiesListComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [ActivitiesListComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/activities/activities.component.spec.ts
+++ b/src/main/ngapp/src/app/activities/activities.component.spec.ts
@@ -38,10 +38,12 @@ describe("ActivitiesComponent", () => {
   }));
 
   it("should be created", () => {
+    console.log("========== [ActivitiesComponent] should be created");
     expect(component).toBeTruthy();
   });
 
   it("should have Activities Title", () => {
+    console.log("========== [ActivitiesComponent] should have Activities Title");
     // query for the title <h2> by CSS element selector
     const de = fixture.debugElement.query(By.css("h2"));
     const el = de.nativeElement;
@@ -49,12 +51,14 @@ describe("ActivitiesComponent", () => {
   });
 
   it("should have Toolbar", () => {
+    console.log("========== [ActivitiesComponent] should have Toolbar");
     // query for the toolbar by css classname
     const de = fixture.debugElement.query(By.css(".toolbar-pf"));
     expect(de).toBeDefined();
   });
 
   it("should have Activities", () => {
+    console.log("========== [ActivitiesComponent] should have Activities");
     // Check component object
     const activities = component.allActivities;
     expect(activities.length).toEqual(3);
@@ -66,6 +70,7 @@ describe("ActivitiesComponent", () => {
   });
 
   it("should have initial card layout", () => {
+    console.log("========== [ActivitiesComponent] should have initial card layout");
     // app-activities-cards should be present
     let debugEl = fixture.debugElement.query(By.css("app-activities-cards"));
     const element = debugEl.nativeElement;
@@ -77,6 +82,7 @@ describe("ActivitiesComponent", () => {
   });
 
   it("should toggle layout", () => {
+    console.log("========== [ActivitiesComponent] should toggle layout");
     // Initial layout should be Card Layout
     let cardDebugElem = fixture.debugElement.query(By.css("app-activities-cards"));
     let listDebugElem = fixture.debugElement.query(By.css("app-activities-list"));
@@ -99,6 +105,7 @@ describe("ActivitiesComponent", () => {
   });
 
   it("should filter activities", () => {
+    console.log("========== [ActivitiesComponent] should filter activities");
     // Expect 3 activities initially.
     let activities = component.filteredActivities;
     expect(activities.length).toEqual(3);

--- a/src/main/ngapp/src/app/activities/add-activity-wizard/add-activity-wizard.component.spec.ts
+++ b/src/main/ngapp/src/app/activities/add-activity-wizard/add-activity-wizard.component.spec.ts
@@ -37,6 +37,7 @@ describe("AddActivityWizardComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [AddActivityWizardComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/activities/add-activity/add-activity.component.spec.ts
+++ b/src/main/ngapp/src/app/activities/add-activity/add-activity.component.spec.ts
@@ -37,6 +37,7 @@ describe("AddActivityComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [AddActivityComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/activities/shared/add-activity-form/add-activity-form.component.spec.ts
+++ b/src/main/ngapp/src/app/activities/shared/add-activity-form/add-activity-form.component.spec.ts
@@ -25,6 +25,7 @@ describe("AddActivityFormComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [AddActivityFormComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/app.component.spec.ts
+++ b/src/main/ngapp/src/app/app.component.spec.ts
@@ -17,6 +17,7 @@ describe("AppComponent", () => {
   }));
 
   it("should create the app", async(() => {
+    console.log("========== [AppComponent] should be created");
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();

--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.spec.ts
@@ -34,6 +34,7 @@ describe("AddConnectionWizardComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [AddConnectionWizardComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/connections/add-connection/add-connection.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/add-connection/add-connection.component.spec.ts
@@ -34,6 +34,7 @@ describe("AddConnectionComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [AddConnectionComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/connections/connections-cards/connections-cards.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/connections-cards/connections-cards.component.spec.ts
@@ -23,6 +23,7 @@ describe("ConnectionsCardsComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [ConnectionCardsComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/connections/connections-list/connections-list.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/connections-list/connections-list.component.spec.ts
@@ -23,6 +23,7 @@ describe("ConnectionsListComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [ConnectionsListComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/connections/connections.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/connections.component.spec.ts
@@ -37,10 +37,12 @@ describe("ConnectionsComponent", () => {
   }));
 
   it("should be created", () => {
+    console.log("========== [ConnectionsComponent] should be created");
     expect(component).toBeTruthy();
   });
 
   it("should have Connections Title", () => {
+    console.log("========== [ConnectionsComponent] should have Connections Title");
     // query for the title <h2> by CSS element selector
     const de = fixture.debugElement.query(By.css("h2"));
     const el = de.nativeElement;
@@ -48,12 +50,14 @@ describe("ConnectionsComponent", () => {
   });
 
   it("should have Toolbar", () => {
+    console.log("========== [ConnectionsComponent] should have Toolbar");
     // query for the toolbar by css classname
     const de = fixture.debugElement.query(By.css(".toolbar-pf"));
     expect(de).toBeDefined();
   });
 
   it("should have Connections", () => {
+    console.log("========== [ConnectionsComponent] should have Connections");
     // Check component object
     const connections = component.allConnections;
     expect(connections.length).toEqual(3);
@@ -65,6 +69,7 @@ describe("ConnectionsComponent", () => {
   });
 
   it("should have initial card layout", () => {
+    console.log("========== [ConnectionsComponent] should have initial card layout");
     // app-connections-cards should be present
     let debugEl = fixture.debugElement.query(By.css("app-connections-cards"));
     const element = debugEl.nativeElement;
@@ -76,6 +81,7 @@ describe("ConnectionsComponent", () => {
   });
 
   it("should toggle layout", () => {
+    console.log("========== [ConnectionsComponent] should toggle layout");
     // Initial layout should be Card Layout
     let cardDebugElem = fixture.debugElement.query(By.css("app-connections-cards"));
     let listDebugElem = fixture.debugElement.query(By.css("app-connections-list"));
@@ -98,6 +104,7 @@ describe("ConnectionsComponent", () => {
   });
 
   it("should filter connections", () => {
+    console.log("========== [ConnectionsComponent] should filter connections");
     // Expect 3 connections initially.
     let connections = component.filteredConnections;
     expect(connections.length).toEqual(3);

--- a/src/main/ngapp/src/app/core/about-dialog/about-dialog.component.spec.ts
+++ b/src/main/ngapp/src/app/core/about-dialog/about-dialog.component.spec.ts
@@ -23,6 +23,7 @@ describe("AboutDialogComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [AboutDialogComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/core/about-dialog/about.service.spec.ts
+++ b/src/main/ngapp/src/app/core/about-dialog/about.service.spec.ts
@@ -15,6 +15,7 @@ describe("AboutService", () => {
   it("should be created",
       inject([ AboutService, AppSettingsService, LoggerService ],
      ( service: AboutService ) => {
-    expect( service ).toBeTruthy();
+        console.log("========== [AboutServiceComponent] should be created");
+        expect( service ).toBeTruthy();
   }));
 });

--- a/src/main/ngapp/src/app/core/api.service.spec.ts
+++ b/src/main/ngapp/src/app/core/api.service.spec.ts
@@ -14,6 +14,7 @@ describe("ApiService", () => {
 
   it("should be created", inject([LoggerService],
                                             (service: MockService ) => {
+    console.log("========== [ApiServiceComponent] should be created");
     expect(service).toBeTruthy();
   }));
 });

--- a/src/main/ngapp/src/app/core/app-settings.service.spec.ts
+++ b/src/main/ngapp/src/app/core/app-settings.service.spec.ts
@@ -10,6 +10,7 @@ describe("AppSettingsService", () => {
   });
 
   it("should be created", inject([AppSettingsService], (service: AppSettingsService) => {
+    console.log("========== [AppSettingsServiceComponent] should be created");
     expect(service).toBeTruthy();
   }));
 });

--- a/src/main/ngapp/src/app/core/breadcrumbs/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/main/ngapp/src/app/core/breadcrumbs/breadcrumb/breadcrumb.component.spec.ts
@@ -23,6 +23,7 @@ describe("BreadcrumbComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [BreadcrumbComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/core/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/main/ngapp/src/app/core/breadcrumbs/breadcrumbs.component.spec.ts
@@ -21,6 +21,7 @@ describe("BreadcrumbsComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [BreadcrumbsComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/core/nav-header/nav-header.component.spec.ts
+++ b/src/main/ngapp/src/app/core/nav-header/nav-header.component.spec.ts
@@ -41,6 +41,7 @@ describe("NavHeaderComponent", () => {
 
   it("should be created", inject([ LoggerService ],
                                             (logger: LoggerService ) => {
+    console.log("========== [NavHeaderComponent] should be created");
     expect(component).toBeTruthy();
   }));
 });

--- a/src/main/ngapp/src/app/core/vertical-nav/vertical-nav.component.spec.ts
+++ b/src/main/ngapp/src/app/core/vertical-nav/vertical-nav.component.spec.ts
@@ -26,6 +26,7 @@ describe("VerticalNavComponent", () => {
 
   it("should be created", inject([ LoggerService ],
     (logger: LoggerService ) => {
+    console.log("========== [VerticalNavComponent] should be created");
     expect(component).toBeTruthy();
   }));
 });

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
@@ -9,7 +9,7 @@
   <pfng-wizard-step [config]="step1Config">
     <h3><i>{{ step1InstructionMessage }}</i></h3>
     <br>
-    <app-connection-table-selector (tableSelectionChanged)="updatePage1ValidStatus()"></app-connection-table-selector>
+    <app-connection-table-selector (selectedTableListUpdated)="updatePage1ValidStatus()"></app-connection-table-selector>
   </pfng-wizard-step>
   <!-- -------------------------- -->
   <!-- Step 2 : Review and Create -->
@@ -35,7 +35,11 @@
         </div>
         <div class="form-group">
           <label class="col-sm-2 control-label">Selected Tables:</label>
-          <label class="col-sm-5">{{ dataserviceSourceTables }}</label>
+          <div class="col-sm-5">
+            <div *ngFor="let table of dataserviceSourceTables">
+              <label>[ {{ table.getConnection().getId() }} ]  {{table.getName()}}</label>
+            </div>
+          </div>
         </div>
       </form>
     </pfng-wizard-substep>

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.spec.ts
@@ -47,6 +47,7 @@ describe("AddDataserviceWizardComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [AddDataserviceWizardComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
@@ -31,6 +31,7 @@ import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
 import { NewDataservice } from "@dataservices/shared/new-dataservice.model";
 import { NotifierService } from "@dataservices/shared/notifier.service";
+import { Table } from "@dataservices/shared/table.model";
 import { VdbStatus } from "@dataservices/shared/vdb-status.model";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { VdbsConstants } from "@dataservices/shared/vdbs-constants";
@@ -368,18 +369,13 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
   /**
    * @returns {string} the selected source table names in string form
    */
-  public get dataserviceSourceTables(): string {
-    let tableStr = "None";
-    const tables = this.tableSelector.getSelectedTables();
-    if (tables.length > 0) {
-      tableStr = tables[0].getConnection().getId() + " [" + tables[0].getName() + "]";
-    }
-    if (tables.length === 2) {
-      tableStr = tableStr + ", " + tables[1].getConnection().getId() + " [" + tables[1].getName() + "]";
-    }
-    return tableStr;
+  public get dataserviceSourceTables(): Table[] {
+    return this.tableSelector.getSelectedTables();
   }
 
+  /**
+   * Updates the page1 status
+   */
   public updatePage1ValidStatus( ): void {
     this.step1Config.nextEnabled = this.tableSelector.valid();
     this.setNavAway(this.step1Config.nextEnabled);

--- a/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.spec.ts
@@ -47,6 +47,7 @@ describe("AddDataserviceComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [AddDataserviceComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.css
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.css
@@ -2,3 +2,12 @@
   padding-left: 0;
   padding-right: 0;
 }
+
+.jdbc-column-title {
+  height: 30px;
+  border:1px solid white;
+  background-color: #cccccc;
+  padding-top: 5px;
+  padding-left: 10px;
+  padding-right: 0;
+}

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.html
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.html
@@ -26,7 +26,7 @@
         </ng-template>
         <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
           <i class="fa fa-plug list-view-pf-icon-sm"></i>
-          {{row.name}}
+          {{ row.name }}
         </ng-template>
       </ngx-datatable-column>
     </ngx-datatable>
@@ -37,19 +37,43 @@
   <!-- 2) Non-JDBC Connection selected             -->
   <!-- 3) No Connection selected                   -->
   <!-- ------------------------------------------- -->
-  <div class="col-sm-9 jdbc-selector-container">
-    <app-jdbc-table-selector [connection]="selectedConnection" (tableSelectionChanged)="onTableSelectionChanged()" *ngIf="hasJdbcConnectionSelected()"></app-jdbc-table-selector>
+  <div class="col-sm-6 jdbc-column-title">
+    <strong>Table Selection</strong>
   </div>
-  <div class="col-sm-9" *ngIf="hasNonJdbcConnectionSelected()">
+  <div class="col-sm-3 jdbc-column-title">
+    <strong>Current Selections</strong>
+  </div>
+  <div class="col-sm-6 jdbc-selector-container">
+    <app-jdbc-table-selector [connection]="selectedConnection"
+                             (tableSelectionAdded)="onTableSelectionAdded($event)"
+                             (tableSelectionRemoved)="onTableSelectionRemoved($event)"
+                             *ngIf="hasJdbcConnectionSelected()">
+    </app-jdbc-table-selector>
+  </div>
+  <div class="col-sm-6" *ngIf="hasNonJdbcConnectionSelected()">
     <div class="alert alert-info">
       <span class="pficon pficon-info"></span>
       <strong>Non-JDBC Connections are not supported</strong>
     </div>
   </div>
-  <div class="col-sm-9" *ngIf="!hasSelectedConnection()">
+  <div class="col-sm-6" *ngIf="!hasSelectedConnection()">
     <div class="alert alert-info">
       <span class="pficon pficon-info"></span>
       <strong>Please select a Connection</strong>
     </div>
+  </div>
+  <!-- ----------------------- -->
+  <!--  Selected Tables List   -->
+  <!-- ----------------------- -->
+  <div class="col-sm-3" *ngIf="!hasSelectedTables">
+      <div class="alert alert-info">
+        <span class="pficon pficon-info"></span>
+        <strong>No tables selected</strong>
+      </div>
+  </div>
+  <div class = "list-div col-sm-3 jdbc-column-results" *ngIf="hasSelectedTables">
+      <div *ngFor="let table of getSelectedTables()">
+        <app-selected-table [table]="table" (selectionListTableRemoved)="onTableSelectionRemoved($event)"></app-selected-table>
+      </div>
   </div>
 </div>

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.spec.ts
@@ -8,6 +8,11 @@ import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { JdbcTableSelectorComponent } from "@dataservices/jdbc-table-selector/jdbc-table-selector.component";
 import { SelectedTableComponent } from "@dataservices/selected-table/selected-table.component";
+import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { NgxDatatableModule } from "@swimlane/ngx-datatable";
 import { ConnectionTableSelectorComponent } from "./connection-table-selector.component";
 
@@ -20,8 +25,10 @@ describe("ConnectionTableSelectorComponent", () => {
       imports: [ FormsModule, HttpModule, NgxDatatableModule ],
       declarations: [ ConnectionTableSelectorComponent, JdbcTableSelectorComponent, SelectedTableComponent ],
       providers: [
-        AppSettingsService, LoggerService,
+        AppSettingsService, LoggerService, NotifierService,
         { provide: ConnectionService, useClass: MockConnectionService },
+        { provide: DataserviceService, useClass: MockDataserviceService },
+        { provide: VdbService, useClass: MockVdbService }
       ]
     })
       .compileComponents().then(() => {
@@ -36,6 +43,7 @@ describe("ConnectionTableSelectorComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [ConnectionTableSelectorComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.spec.ts
@@ -23,6 +23,7 @@ describe("DataservicesCardsComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [DataservicesCardsComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.spec.ts
@@ -23,6 +23,7 @@ describe("DataservicesListComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [DataservicesListComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
@@ -51,10 +51,12 @@ describe("DataservicesComponent", () => {
   }));
 
   it("should be created", () => {
+    console.log("========== [DataservicesComponent] should be created");
     expect(component).toBeTruthy();
   });
 
   it("should have Dataservices Title", () => {
+    console.log("========== [DataservicesComponent] should have Dataservices Title");
     // query for the title <h2> by CSS element selector
     const de = fixture.debugElement.query(By.css("h2"));
     const el = de.nativeElement;
@@ -62,12 +64,14 @@ describe("DataservicesComponent", () => {
   });
 
   it("should have Toolbar", () => {
+    console.log("========== [DataservicesComponent] should have Toolbar");
     // query for the toolbar by css classname
     const de = fixture.debugElement.query(By.css(".toolbar-pf"));
     expect(de).toBeDefined();
   });
 
   it("should have Dataservices", () => {
+    console.log("========== [DataservicesComponent] should have Dataservices");
     // Check component object
     const dataservices = component.allDataservices;
     expect(dataservices.length).toEqual(3);
@@ -79,6 +83,7 @@ describe("DataservicesComponent", () => {
   });
 
   it("should have initial card layout", () => {
+    console.log("========== [DataservicesComponent] should have initial card layout");
     // app-dataservices-cards should be present
     let debugEl = fixture.debugElement.query(By.css("app-dataservices-cards"));
     const element = debugEl.nativeElement;
@@ -90,6 +95,7 @@ describe("DataservicesComponent", () => {
   });
 
   it("should toggle layout", () => {
+    console.log("========== [DataservicesComponent] should toggle layout");
     // Initial layout should be Card Layout
     let cardDebugElem = fixture.debugElement.query(By.css("app-dataservices-cards"));
     let listDebugElem = fixture.debugElement.query(By.css("app-dataservices-list"));
@@ -112,6 +118,7 @@ describe("DataservicesComponent", () => {
   });
 
   it("should filter dataservices", () => {
+    console.log("========== [DataservicesComponent] should filter dataservices");
     // Expect 3 dataservices initially.
     let dataservices = component.filteredDataservices;
     expect(dataservices.length).toEqual(3);

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.css
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.css
@@ -34,10 +34,10 @@
 }
 
 .jdbc-column-title {
-  height: 35px;
+  height: 20px;
   border:1px solid white;
   background-color: #cccccc;
-  padding-top: 7px;
+  padding-top: 0;
   padding-left: 10px;
   padding-right: 0;
 }

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.html
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.html
@@ -1,34 +1,31 @@
 <!-- ------------- -->
 <!-- Column Titles -->
 <!-- ------------- -->
-<div class="col-sm-4 jdbc-column-title">
+<div class="col-sm-6 jdbc-column-title">
   <strong>Schemas</strong>
 </div>
-<div class="col-sm-4 jdbc-column-title">
+<div class="col-sm-6 jdbc-column-title">
   <strong>Tables</strong>
-</div>
-<div class="col-sm-4 jdbc-column-title">
-  <strong>Selections</strong>
 </div>
 <!-- ------------- -->
 <!-- Schemas List  -->
 <!-- ------------- -->
-<div class="col-sm-4" *ngIf="schemasLoading">
+<div class="col-sm-6" *ngIf="schemasLoading">
   <span class="spinner spinner-sm spinner-inline"></span>
 </div>
-<div class="col-sm-4" *ngIf="schemasLoadedInvalid">
+<div class="col-sm-6" *ngIf="schemasLoadedInvalid">
   <div class="alert alert-info">
     <span class="pficon pficon-info"></span>
     <strong>Unable to load schema</strong>
   </div>
 </div>
-<div class="col-sm-4" *ngIf="schemasLoadedValidEmpty">
+<div class="col-sm-6" *ngIf="schemasLoadedValidEmpty">
   <div class="alert alert-info">
     <span class="pficon pficon-info"></span>
     <strong>No schema available</strong>
   </div>
 </div>
-<div class="list-div col-sm-4 jdbc-column-results" *ngIf="schemasLoadedValidNotEmpty">
+<div class="list-div col-sm-6 jdbc-column-results" *ngIf="schemasLoadedValidNotEmpty">
   <div class="jdbc-list list-group list-view-pf">
     <div class="list-group-item list-view-pf-stacked"
          *ngFor="let schema of getSchemas(); index as i; odd as isEvenRow; even as isOddRow"
@@ -49,28 +46,28 @@
 <!-- ------------- -->
 <!--  Tables List  -->
 <!-- ------------- -->
-<div class="col-sm-4" *ngIf="hasSelectedSchema && tablesLoading">
+<div class="col-sm-6" *ngIf="hasSelectedSchema && tablesLoading">
   <span class="spinner spinner-sm spinner-inline"></span>
 </div>
-<div class="col-sm-4" *ngIf="hasSelectedSchema && tablesLoadedInvalid">
+<div class="col-sm-6" *ngIf="hasSelectedSchema && tablesLoadedInvalid">
   <div class="alert alert-info">
     <span class="pficon pficon-info"></span>
     <strong>Unable to load tables</strong>
   </div>
 </div>
-<div class="col-sm-4" *ngIf="hasSelectedSchema && tablesLoadedValidEmpty">
+<div class="col-sm-6" *ngIf="hasSelectedSchema && tablesLoadedValidEmpty">
   <div class="alert alert-info">
     <span class="pficon pficon-info"></span>
     <strong>No tables available</strong>
   </div>
 </div>
-<div class = "list-div col-sm-4 jdbc-column-results" *ngIf="hasSelectedSchema && tablesLoadedValidNotEmpty">
+<div class = "list-div col-sm-6 jdbc-column-results" *ngIf="hasSelectedSchema && tablesLoadedValidNotEmpty">
   <div class="jdbc-list list-group list-view-pf">
     <div class="list-group-item list-view-pf-stacked"
          *ngFor="let table of getTables(); index as i; odd as isEvenRow; even as isOddRow"
          [class.oddRow]="isOddRow" [class.evenRow]="isEvenRow">
       <div class="list-view-pf-checkbox">
-        <input type="checkbox" title="" [(ngModel)]="table.selected" (change)="selectedTablesChanged()">
+        <input type="checkbox" title="" [(ngModel)]="table.selected" (change)="selectedTablesChanged(table)">
       </div>
       <div class="list-view-pf-main-info">
         <div class="list-view-pf-body">
@@ -82,19 +79,5 @@
         </div>
       </div>
     </div>
-  </div>
-</div>
-<!-- ----------------------- -->
-<!--  Table Selections List  -->
-<!-- ----------------------- -->
-<div class="col-sm-4" *ngIf="hasSelectedSchema && !hasSelectedTables()">
-  <div class="alert alert-info">
-    <span class="pficon pficon-info"></span>
-    <strong>No tables selected</strong>
-  </div>
-</div>
-<div class = "list-div col-sm-4 jdbc-column-results" *ngIf="hasSelectedSchema && hasSelectedTables()">
-  <div *ngFor="let table of getSelectedTables()">
-    <app-selected-table [table]="table"></app-selected-table>
   </div>
 </div>

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.spec.ts
@@ -7,6 +7,11 @@ import { MockConnectionService } from "@connections/shared/mock-connection.servi
 import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { SelectedTableComponent } from "@dataservices/selected-table/selected-table.component";
+import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { JdbcTableSelectorComponent } from "./jdbc-table-selector.component";
 
 describe("JdbcTableSelectorComponent", () => {
@@ -18,8 +23,10 @@ describe("JdbcTableSelectorComponent", () => {
       imports: [ FormsModule, HttpModule ],
       declarations: [ JdbcTableSelectorComponent, SelectedTableComponent ],
       providers: [
-        AppSettingsService, LoggerService,
+        AppSettingsService, LoggerService, NotifierService,
         { provide: ConnectionService, useClass: MockConnectionService },
+        { provide: DataserviceService, useClass: MockDataserviceService },
+        { provide: VdbService, useClass: MockVdbService },
       ]
     })
       .compileComponents().then(() => {
@@ -34,6 +41,7 @@ describe("JdbcTableSelectorComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [JdbcTableSelectorComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/dataservices/selected-table/selected-table.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/selected-table/selected-table.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
-import { Connection } from "../../connections/shared/connection.model";
+import { Connection } from "@connections/shared/connection.model";
 import { Table } from "../shared/table.model";
 import { SelectedTableComponent } from "./selected-table.component";
 

--- a/src/main/ngapp/src/app/dataservices/selected-table/selected-table.component.ts
+++ b/src/main/ngapp/src/app/dataservices/selected-table/selected-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { Table } from "@dataservices/shared/table.model";
 
 @Component({
@@ -9,6 +9,7 @@ import { Table } from "@dataservices/shared/table.model";
 export class SelectedTableComponent implements OnInit {
 
   @Input() public table: Table;
+  @Output() public selectionListTableRemoved: EventEmitter<Table> = new EventEmitter<Table>();
 
   constructor() {
     // nothing to do
@@ -20,5 +21,6 @@ export class SelectedTableComponent implements OnInit {
 
   public onRemove(): void {
     this.table.selected = false;
+    this.selectionListTableRemoved.emit(this.table);
   }
 }

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -16,7 +16,7 @@
  */
 
 import { Injectable } from "@angular/core";
-import { Http } from "@angular/http";
+import { Http, Response } from "@angular/http";
 import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
@@ -29,6 +29,7 @@ import "rxjs/add/observable/throw";
 import "rxjs/add/operator/catch";
 import "rxjs/add/operator/map";
 import { Observable } from "rxjs/Observable";
+import { ErrorObservable } from "rxjs/observable/ErrorObservable";
 
 @Injectable()
 export class MockDataserviceService extends DataserviceService {
@@ -102,6 +103,22 @@ export class MockDataserviceService extends DataserviceService {
    */
   public pollDataserviceStatus(pollIntervalSec: number): void {
     // Nothing to do
+  }
+
+  /**
+   * Query a Dataservice via the komodo rest interface
+   * @param {string} query the SQL query
+   * @param {string} dataserviceName the dataservice name
+   * @param {number} limit the limit for the number of result rows
+   * @param {number} offset the offset for the result rows
+   * @returns {Observable<boolean>}
+   */
+  public queryDataservice(query: string, dataserviceName: string, limit: number, offset: number): Observable<any> {
+    return Observable.of<any>();
+  }
+
+  protected handleError(error: Response): ErrorObservable {
+    return Observable.throw(error);
   }
 
 }

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
@@ -41,6 +41,7 @@ describe("SqlControlComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [SqlControlComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
@@ -39,6 +39,7 @@ describe("TestDataserviceComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [TestDataserviceComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/shared/confirm-delete/confirm-delete.component.spec.ts
+++ b/src/main/ngapp/src/app/shared/confirm-delete/confirm-delete.component.spec.ts
@@ -23,6 +23,7 @@ describe("ConfirmDeleteComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [ConfirmDeleteComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/shared/page-error/page-error.component.spec.ts
+++ b/src/main/ngapp/src/app/shared/page-error/page-error.component.spec.ts
@@ -24,6 +24,7 @@ describe("PageErrorComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [PageErrorComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/shared/page-not-found/page-not-found.component.spec.ts
+++ b/src/main/ngapp/src/app/shared/page-not-found/page-not-found.component.spec.ts
@@ -21,6 +21,7 @@ describe("PageNotFoundComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [PageNotFoundComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/app/shared/property-form/property-form.component.spec.ts
+++ b/src/main/ngapp/src/app/shared/property-form/property-form.component.spec.ts
@@ -41,6 +41,7 @@ describe("PropertyFormComponent", () => {
   });
 
   it("should be created", () => {
+    console.log("========== [PropertyFormComponent] should be created");
     expect(component).toBeTruthy();
   });
 });

--- a/src/main/ngapp/src/styles.css
+++ b/src/main/ngapp/src/styles.css
@@ -57,5 +57,6 @@
 }
 
 .datatable-body-row.active .datatable-row-group {
-  background-color: #39a5dc !important;
+  background-color: darkblue !important;
+  color: white;
 }


### PR DESCRIPTION
Changes to reorganize the AddDataservice Wizard.  
- a lot of minor changes to the tests.  Adds log message in each test, which makes it easier to identify failures in the output.
- reorganized the ConnectionTableSelector component to include the accumulator list of selected tables.  The selected tables are maintained in the DataserviceService.
- reorganized handling of adds and removes of the selected tables to utilize the dataservice functions
- other minor layout changes
