### PR TITLE
Allows edit of dataservices

### DIFF
--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
@@ -37,7 +37,7 @@
           <label class="col-sm-2 control-label">Selected Tables:</label>
           <div class="col-sm-5">
             <div *ngFor="let table of dataserviceSourceTables">
-              <label>[ {{ table.getConnection().getId() }} ]  {{table.getName()}}</label>
+              <label>[ {{ table.getConnection().getId() }} ] {{ table.getName() }}</label>
             </div>
           </div>
         </div>
@@ -49,22 +49,22 @@
         <!-- In progress -->
         <div class="wizard-pf-process blank-slate-pf" *ngIf="!createComplete">
           <div class="spinner spinner-lg blank-slate-pf-icon"></div>
-          <h3 class="blank-slate-pf-main-action">Creation in progress</h3>
-          <p class="blank-slate-pf-secondary-action">The dataservice is being created. </p>
+          <h3 class="blank-slate-pf-main-action">{{ finalPageTitle }}</h3>
+          <p class="blank-slate-pf-secondary-action">{{ finalPageMessage }}</p>
         </div>
         <!-- Create Successful -->
         <div class="wizard-pf-complete blank-slate-pf" *ngIf="createComplete && createSuccessful">
           <div class="wizard-pf-success-icon"><span class="glyphicon glyphicon-ok-circle"></span></div>
-          <h3 class="blank-slate-pf-main-action">Creation was successful</h3>
-          <p class="blank-slate-pf-secondary-action">The dataservice was created successfully. Click on the button to see all dataservices.</p>
+          <h3 class="blank-slate-pf-main-action">{{ finalPageTitle }}</h3>
+          <p class="blank-slate-pf-secondary-action">{{ finalPageMessage }}</p>
           <button class="btn btn-lg btn-primary" type="button" (click)="onDeployDataservice()">View All Dataservices</button>
         </div>
         <!-- Create Failed -->
         <div class="wizard-pf-complete blank-slate-pf" *ngIf="createComplete && !createSuccessful">
           <div class="wizard-pf-failed-icon"><span class="glyphicon glyphicon-remove-circle"></span></div>
-          <h3 class="blank-slate-pf-main-action">Creation failed</h3>
+          <h3 class="blank-slate-pf-main-action">{{ finalPageTitle }}</h3>
           <div class="blank-slate-pf-secondary-action">
-            The dataservice creation failed!
+            {{ finalPageMessage }}
             <br>
             <div style="font-style: italic;">{{ errorDetails }}</div>
           </div>

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.html
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.html
@@ -1,8 +1,8 @@
 <div>
-  <div *ngIf="connectionsLoading">
+  <div class="col-sm-3" *ngIf="connectionsLoading">
     <span class="spinner spinner-sm spinner-inline"></span>
   </div>
-  <div class="alert-padding" *ngIf="connectionsLoadedInvalid">
+  <div class="col-sm-3 alert-padding" *ngIf="connectionsLoadedInvalid">
     <div class="alert alert-info">
       <span class="pficon pficon-info"></span>
       <strong>Problem Loading Connections!</strong>

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.ts
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.ts
@@ -65,9 +65,6 @@ export class ConnectionTableSelectorComponent implements OnInit {
    * Component initialization
    */
   public ngOnInit(): void {
-    // clears table selections
-    this.wizardService.clearWizardSelectedTables();
-
     // Load the connections
     this.connectionLoadingState = LoadingState.LOADING;
     const self = this;
@@ -215,6 +212,7 @@ export class ConnectionTableSelectorComponent implements OnInit {
     const wasRemoved = this.wizardService.removeFromWizardSelectionTables(removedTable);
     if (wasRemoved) {
       this.selectedTableListUpdated.emit();
+      this.jdbcTableSelector.deselectTable(removedTable);
     }
   }
 

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.html
@@ -16,6 +16,8 @@
             <span><a [routerLink]="[dataservice.getId()]">{{ dataservice.getId() }}</a></span>
             <span *ngIf="!dataservice.serviceDeploymentLoading" class="pull-right pficon-delete dataservice-card-action-icon" style="color:darkred;" (click)="onDeleteDataservice(dataservice.getId())"></span>
             <span *ngIf="dataservice.serviceDeploymentLoading" class="pull-right pficon-delete dataservice-card-action-disabled-icon"></span>
+            <span *ngIf="!dataservice.serviceDeploymentLoading" class="pull-right fa fa-edit dataservice-card-action-icon" (click)="onEditDataservice(dataservice.getId())"></span>
+            <span *ngIf="dataservice.serviceDeploymentLoading" class="pull-right fa fa-edit dataservice-card-action-disabled-icon"></span>
             <span *ngIf="!dataservice.serviceDeploymentLoading" class="pull-right pficon-export dataservice-card-action-icon" (click)="onPublishDataservice(dataservice.getId())"></span>
             <span *ngIf="dataservice.serviceDeploymentLoading" class="pull-right pficon-export dataservice-card-action-disabled-icon"></span>
             <span *ngIf="dataservice.serviceDeploymentActive" class="pull-right fa fa-list-alt dataservice-card-action-icon" (click)="onTestDataservice(dataservice.getId())"></span>

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
@@ -35,6 +35,7 @@ export class DataservicesCardsComponent {
   @Output() public testDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public publishDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteDataservice: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public editDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public quickLookDataservice: EventEmitter<string> = new EventEmitter<string>();
 
   /**
@@ -70,6 +71,10 @@ export class DataservicesCardsComponent {
 
   public onDeleteDataservice(dataserviceName: string): void {
     this.deleteDataservice.emit(dataserviceName);
+  }
+
+  public onEditDataservice(dataserviceName: string): void {
+    this.editDataservice.emit(dataserviceName);
   }
 
   public onQuickLookDataservice(dataserviceName: string): void {

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
@@ -43,6 +43,8 @@
                 (click)="onTestDataservice(dataservice.getId())" [disabled]="!dataservice.serviceDeploymentActive">Test</button>
         <button i18n="@@dataservicesList.publish" class="btn btn-default" type="button"
                 (click)="onPublishDataservice(dataservice.getId())" [disabled]="dataservice.serviceDeploymentLoading">Publish</button>
+        <button i18n="@@dataservicesList.edit" class="btn btn-default" type="button"
+                (click)="onEditDataservice(dataservice.getId())" [disabled]="dataservice.serviceDeploymentLoading">Edit</button>
         <button i18n="@@dataservicesList.delete" class="btn btn-danger" type="button"
                 (click)="onDeleteDataservice(dataservice.getId())" [disabled]="dataservice.serviceDeploymentLoading">Delete</button>
       </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
@@ -36,6 +36,7 @@ export class DataservicesListComponent {
   @Output() public testDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public publishDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteDataservice: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public editDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public quickLookDataservice: EventEmitter<string> = new EventEmitter<string>();
 
   private router: Router;
@@ -73,6 +74,10 @@ export class DataservicesListComponent {
 
   public onDeleteDataservice(dataserviceName: string): void {
     this.deleteDataservice.emit(dataserviceName);
+  }
+
+  public onEditDataservice(dataserviceName: string): void {
+    this.editDataservice.emit(dataserviceName);
   }
 
   public onQuickLookDataservice(dataserviceName: string): void {

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -28,7 +28,7 @@
             </button>
           </div>
           <div class="form-group">
-            <a i18n="@@dataservices.addDataservice" class="btn btn-primary" [routerLink]="[addDataserviceLink]">Add Dataservice</a>
+            <a i18n="@@dataservices.addDataservice" class="btn btn-primary" (click)="onNew()">Add Dataservice</a>
           </div>
           <div class="form-group toolbar-pf-view-selector">
             <ul class="list-inline">
@@ -60,7 +60,7 @@
           </p>
           <div class="blank-slate-pf-main-action">
             <div class="btn-group">
-              <a i18n="@@dataservices.addDataservice" class="btn btn-primary btn-lg" [routerLink]="[ addDataserviceLink ]">Add Dataservice</a>
+              <a i18n="@@dataservices.addDataservice" class="btn btn-primary btn-lg" (click)="onNew()">Add Dataservice</a>
             </div>
           </div>
         </div>
@@ -101,12 +101,12 @@
           <app-dataservices-list *ngIf="isListLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
                                  (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
                                  (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
-                                 (quickLookDataservice)="onQuickLook($event)"
+                                 (editDataservice)="onEdit($event)" (quickLookDataservice)="onQuickLook($event)"
                                  (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-list>
           <app-dataservices-cards *ngIf="isCardLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
                                   (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
                                   (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
-                                  (quickLookDataservice)="onQuickLook($event)"
+                                  (editDataservice)="onEdit($event)" (quickLookDataservice)="onQuickLook($event)"
                                   (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"></app-dataservices-cards>
         </div>
       </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
@@ -13,6 +13,7 @@ import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.se
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
+import { WizardService } from "@dataservices/shared/wizard.service";
 import { SqlControlComponent } from "@dataservices/sql-control/sql-control.component";
 import { SharedModule } from "@shared/shared.module";
 import { NgxDatatableModule } from "@swimlane/ngx-datatable";
@@ -32,6 +33,7 @@ describe("DataservicesComponent", () => {
       providers: [
         AppSettingsService,
         NotifierService,
+        WizardService,
         { provide: VdbService, useClass: MockVdbService }
       ]
     });

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.ts
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.ts
@@ -250,6 +250,23 @@ export class JdbcTableSelectorComponent implements OnInit, TableSelector {
     }
   }
 
+  /**
+   * Deselects the table if one with a matching name and connection is currently selected
+   * @param {Table} table
+   */
+  public deselectTable(table: Table): void {
+    const connName = table.getConnection().getId();
+    const tableName = table.getName();
+    for (const theTable of this.tables) {
+      const theConnName = theTable.getConnection().getId();
+      const theTableName = theTable.getName();
+      if (theConnName === connName && theTableName === tableName) {
+        theTable.selected = false;
+        break;
+      }
+    }
+  }
+
   /*
    * Builds the array of CatalogSchema items from the SchemaInfo coming from
    * the Komodo rest call
@@ -319,15 +336,15 @@ export class JdbcTableSelectorComponent implements OnInit, TableSelector {
   private setInitialTableSelections(): void {
     for ( const table of this.tables ) {
       // const catName = table.getCatalogName();
-      const schemaName = table.getSchemaName();
+      // const schemaName = table.getSchemaName();
       const tableName = table.getName();
       const connName = table.getConnection().getId();
       for ( const initialTable of this.wizardService.getWizardSelectedTables() ) {
         // const iCatName = initialTable.getCatalogName();
-        const iSchemaName = initialTable.getSchemaName();
+        // const iSchemaName = initialTable.getSchemaName();
         const iTableName = initialTable.getName();
         const iConnName = initialTable.getConnection().getId();
-        if (iConnName === connName && iTableName === tableName && iSchemaName === schemaName ) {
+        if (iConnName === connName && iTableName === tableName ) {
           table.selected = true;
           break;
         }

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
@@ -275,6 +275,18 @@ export class DataserviceService extends ApiService {
   }
 
   /**
+   * Updates a dataservice with single table source.  This is simply a create, with the added step of
+   * deleting the existing workspace dataservice first.
+   * @param {NewDataservice} dataservice
+   * @param {Table} sourceTable
+   * @returns {Observable<boolean>}
+   */
+  public updateDataserviceForSingleTable(dataservice: NewDataservice, sourceTable: Table): Observable<boolean> {
+    return this.deleteDataservice(dataservice.getId())
+      .flatMap((res) => this.createDataserviceForSingleTable(dataservice, sourceTable));
+  }
+
+  /**
    * Export a dataservice to a git repository
    * @param {string} dataserviceName the dataservice name
    * @returns {Observable<boolean>}

--- a/src/main/ngapp/src/app/dataservices/shared/table-selector.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/table-selector.ts
@@ -23,22 +23,28 @@ import { Table } from "@dataservices/shared/table.model";
  */
 export interface TableSelector {
 
-  /*
+  /**
    * Set the connection for this jdbc table selector
    * @param {Connection} conn the jdbc connection
    */
   setConnection(conn: Connection): void;
 
-  /*
+  /**
    * Determine if any tables are currently selected
    * @returns {boolean} true if one or more tables are selected
    */
   hasSelectedTables( ): boolean;
 
-  /*
+  /**
    * Get the array of currently selected Tables
    * @returns {Table[]} the array of selected Tables (never null, but may be empty)
    */
   getSelectedTables(): Table[];
+
+  /**
+   * Deselect the table if a table with the same name and connection is currently selected.
+   * @param {Table} table the table to deselect
+   */
+  deselectTable(table: Table): void;
 
 }

--- a/src/main/ngapp/src/app/dataservices/shared/wizard.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/wizard.service.ts
@@ -5,11 +5,27 @@ import { Table } from "@dataservices/shared/table.model";
 export class WizardService {
 
   private wizardSelectedTablesArray: Table[] = [];
+  private edit = false;
 
   constructor() {
     // Nothing to do
   }
 
+  /**
+   * Sets edit mode
+   * @param {boolean} isEdit 'true' if editing, 'false' if not.
+   */
+  public setEdit(isEdit: boolean): void {
+    this.edit = isEdit;
+  }
+
+  /**
+   * Gets the edit mode
+   * @returns {boolean} 'true' if editing, 'false' if not.
+   */
+  public isEdit(): boolean {
+    return this.edit;
+  }
   /**
    * Get the wizard table selections
    * @returns {Table[]} the selections

--- a/src/main/ngapp/src/styles.css
+++ b/src/main/ngapp/src/styles.css
@@ -51,10 +51,7 @@
 }
 
 .datatable-body-cell {
-  padding-bottom: 0.25em;
-  padding-left: 1.0em;
-  padding-right: 0.25em;
-  padding-top: 0.25em;
+  padding: 0.25em 0.25em 0.25em 1.0em;
   border-left: 1px solid #d8d8d8;
   border-right: 1px solid #d8d8d8;
 }


### PR DESCRIPTION
Changes to allow edit of existing dataservices, plus other minor fixes.  Currently the user cannot edit the dataservice name or description, but we may be able to relax that restriction in the future.
- Adds edit action to the dataservice card and list.
- now tracks edit vs create in the WizardService.
- wording in the wizard now changes for edit vs create.
- changes to DataserviceService to support the update.
- other minor changes to fix selection issues and button enablement issue.
