### PR TITLE
Adds support for multiple dataservice views

### DIFF
--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.html
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.html
@@ -81,7 +81,7 @@
         <strong>No tables selected</strong>
       </div>
   </div>
-  <div class = "list-div col-sm-3" *ngIf="hasSelectedTables">
+  <div class = "col-sm-3" *ngIf="hasSelectedTables">
       <div *ngFor="let table of getSelectedTables()">
         <app-selected-table [table]="table" (selectionListTableRemoved)="onTableSelectionRemoved($event)"></app-selected-table>
       </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.css
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.css
@@ -95,3 +95,9 @@ a.clear-filters {
   cursor: pointer;
   font-size: 1.5em;
 }
+
+.quicklook-title {
+  margin-left: 50px;
+  font-size: 1.25em;
+  font-weight: bold;
+}

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -112,12 +112,15 @@
       </div>
       <div class="col-md-12 {{resultsAreaCss}}" *ngIf="showResults">
         <hr class="dataservice-results-hr">
-        <span class="pull-left fa fa-list-alt dataservice-results-action-icon" (click)="onTest(quickLookServiceName)"></span>
-        <span class="pull-left fa fa-refresh dataservice-results-action-icon-refresh" (click)="onSubmitQuickLookQuery()"></span>
-        <span class="pull-right fa fa-fw fa-close dataservice-results-action-icon-close" (click)="setQuickLookPanelOpenState(false)"></span>
-        <h3 style="margin-left: 75px">Quick Look Results for Dataservice &apos;<strong>{{ quickLookServiceName }}</strong>&apos;</h3>
+        <div>
+          <span class="pull-left fa fa-list-alt dataservice-results-action-icon" (click)="onTest(quickLookServiceName)"></span>
+          <span class="pull-left fa fa-refresh dataservice-results-action-icon-refresh" (click)="onSubmitQuickLookQuery()"></span>
+          <span class="quicklook-title">Quick Look Results for Dataservice '{{ quickLookServiceName }}'</span>
+          <span class="pull-right fa fa-fw fa-close dataservice-results-action-icon-close" (click)="setQuickLookPanelOpenState(false)"></span>
+        </div>
         <br>
-        <app-sql-control [editorVisible]="editorVisible" ></app-sql-control>
+        <app-sql-control [quicklook]="true" [selectedViews]="selectedViews" [serviceViews]="allServiceViews"
+                                            [viewSql]="quickLookSql"></app-sql-control>
       </div>
     </div>
 

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
@@ -54,6 +54,7 @@ export class DataserviceService extends ApiService {
   private appSettingsService: AppSettingsService;
   private vdbService: VdbService;
   private selectedDataservice: Dataservice;
+  private dataserviceCurrentView: Table[] = [];
   private cachedDataserviceStates: Map<string, DeploymentState> = new Map<string, DeploymentState>();
   private updatesSubscription: Subscription;
 
@@ -74,6 +75,12 @@ export class DataserviceService extends ApiService {
    */
   public setSelectedDataservice(service: Dataservice): void {
     this.selectedDataservice = service;
+    // When the dataservice is selected, init the selected view
+    const views: Table[] = this.getSelectedDataserviceViews();
+    this.dataserviceCurrentView = [];
+    if (views && views.length > 0) {
+      this.dataserviceCurrentView.push(views[0]);
+    }
   }
 
   /**
@@ -82,6 +89,47 @@ export class DataserviceService extends ApiService {
    */
   public getSelectedDataservice( ): Dataservice {
     return this.selectedDataservice;
+  }
+
+  /**
+   * Get the current Dataservice selection's views.  The table object is used for the view,
+   * with the Table name set to the full "modelName"."viewName" of the view.
+   * @returns {Table[]} the selected Dataservice views
+   */
+  public getSelectedDataserviceViews( ): Table[] {
+    if (!this.selectedDataservice || this.selectedDataservice === null) {
+      return [];
+    }
+
+    const modelName = this.selectedDataservice.getServiceViewModel();
+    const serviceView = this.selectedDataservice.getServiceViewName();
+
+    // TODO: we will need to get multiple views when supported
+    const view1: Table = new Table();
+    view1.setName(modelName + "." + serviceView);
+
+    const allViews: Table[] = [];
+    allViews.push(view1);
+
+    return allViews;
+  }
+
+  /**
+   * Get the current Dataservice current view.  The table object is used for the view,
+   * with the Table name set to the full "modelName"."viewName" of the view.
+   * @returns {Table[]} the Dataservice current view
+   */
+  public getSelectedDataserviceCurrentView( ): Table[] {
+    return this.dataserviceCurrentView;
+  }
+
+  /**
+   * Set the current Dataservice current view.  The table object is used for the view,
+   * with the Table name set to the full "modelName"."viewName" of the view.
+   * @param {Table[]} view the current view
+   */
+  public setSelectedDataserviceCurrentView( view: Table[] ): void {
+    this.dataserviceCurrentView = view;
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -23,6 +23,7 @@ import { Dataservice } from "@dataservices/shared/dataservice.model";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { NewDataservice } from "@dataservices/shared/new-dataservice.model";
 import { NotifierService } from "@dataservices/shared/notifier.service";
+import { Table } from "@dataservices/shared/table.model";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import "rxjs/add/observable/of";
 import "rxjs/add/observable/throw";
@@ -88,6 +89,19 @@ export class MockDataserviceService extends DataserviceService {
    */
   public getSelectedDataservice( ): Dataservice {
     return this.serv1;
+  }
+
+  /**
+   * Get the views for the selected Dataservice
+   * @returns {Table[]} the views
+   */
+  public getSelectedDataserviceViews(): Table[] {
+    const table: Table = new Table();
+    table.setName("views.View1");
+    const tables: Table[] = [];
+    tables.push(table);
+
+    return tables;
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.css
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.css
@@ -1,6 +1,23 @@
+.view-table-full-div {
+  padding-left: 0;
+  padding-right: 10px;
+  min-height: 240px;
+  max-height: 240px;
+  border: 1px inset grey;
+  overflow-y: auto;
+}
+
+.view-table-quicklook-div {
+  padding-left: 0;
+  padding-right: 10px;
+  min-height: 120px;
+  max-height: 120px;
+  border: 1px inset grey;
+  overflow-y: auto;
+}
+
 .sql-control-control-title {
-  margin: 0.5em;
-  float: left;
+  margin: 5px 0 0;
   color: grey;
   font-weight: bold;
 }
@@ -10,11 +27,14 @@
 }
 
 .sql-control-editor {
-  clear: both;
   border: 1px inset grey;
+  margin-left: 15px;
+  padding-left: 0;
 }
 
 .sql-results-panel {
+  padding-left: 0;
+  padding-right: 0;
   clear: both;
   border: 1px inset grey;
 }
@@ -29,4 +49,16 @@
 
 .row-number-column {
   text-align: center;
+}
+
+.quicklook-sql-title {
+  font-size: 1.25em;
+  font-weight: bold;
+}
+
+.quicklook-sql {
+  margin-left: 15px;
+  font-size: 1.15em;
+  font-weight: bold;
+  font-style: italic;
 }

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.html
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.html
@@ -1,14 +1,36 @@
 <div class="row">
-  <div class="col-sm-12" *ngIf="editorVisible">
-    <div class="sql-control-control-title">Query Editor</div>
-
-    <div class="col-sm-12 sql-control-editor">
+  <div class="col-sm-12">
+    <div [ngClass]="quicklook ? 'col-sm-3 view-table-quicklook-div': 'col-sm-3 view-table-full-div'">
+      <ngx-datatable [rows]="serviceViews"
+                     [footerHeight]="0"
+                     [scrollbarV]="false"
+                     [scrollbarH]="true"
+                     [columnMode]="'force'"
+                     [reorderable]="false"
+                     [selectionType]="'single'"
+                     [selected]="selectedViews"
+                     (select)="onViewSelect($event)"
+                     [sorts]="[{prop: 'name', dir: 'asc'}]"
+                     [cssClasses]="customClasses">
+        <ngx-datatable-column name="Dataservice Views"
+                              [prop]="'name'"
+                              [sortable]="true"
+                              [width]="100"
+                              [draggable]="false"
+                              [resizeable]="false">
+        </ngx-datatable-column>
+      </ngx-datatable>
+    </div>
+    <div *ngIf="!quicklook" class="col-sm-8 sql-control-editor">
       <codemirror [(ngModel)]="queryText" [config]="config"></codemirror>
       <div class="row sql-control-controls-query">
         <button class="btn btn-primary" (click)="submitCurrentQuery()">
           <span class="fa fa-fw fa-search"></span>Submit
         </button>
       </div>
+    </div>
+    <div *ngIf="quicklook" class="col-sm-9">
+      <span class="quicklook-sql-title">SQL:</span><span class="quicklook-sql">{{ queryText }}</span>
     </div>
   </div>
 
@@ -31,7 +53,7 @@
     <div class="col-sm-12" *ngIf="queryRanInvalid">
       <div class="alert alert-info">
         <span class="pficon pficon-info"></span>
-        <strong>There was an error running the Query!</strong>
+        <strong>Error running Query for <i>'{{ viewName }}'</i></strong>
       </div>
     </div>
     <div class="col-sm-12 sql-results-panel" *ngIf="queryRanValid">

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
@@ -8,6 +8,7 @@ import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
+import { Table } from "@dataservices/shared/table.model";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { NgxDatatableModule } from "@swimlane/ngx-datatable";
 import { CodemirrorModule } from "ng2-codemirror";
@@ -37,6 +38,16 @@ describe("SqlControlComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SqlControlComponent);
     component = fixture.componentInstance;
+
+    // Set the inputs for the component
+    component.viewSql = "SELECT * FROM views.View1";
+    const table = new Table();
+    table.setName("views.View1");
+    const tables: Table[] = [];
+    tables.push(table);
+    component.serviceViews = tables;
+    component.selectedViews = tables;
+
     fixture.detectChanges();
   });
 

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.html
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.html
@@ -24,7 +24,8 @@
       </div>
     </div>
     <div class="col-sm-10" *ngIf="pageLoadedValid">
-      <app-sql-control></app-sql-control>
+      <app-sql-control [quicklook]="false" [selectedViews]="selectedViews" [serviceViews]="allServiceViews"
+                       [viewSql]="quickLookSql"></app-sql-control>
     </div>
   </div>
 </div>

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.ts
@@ -5,6 +5,7 @@ import { LoggerService } from "@core/logger.service";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
+import { Table } from "@dataservices/shared/table.model";
 import { AbstractPageComponent } from "@shared/abstract-page.component";
 import { LoadingState } from "@shared/loading-state.enum";
 
@@ -22,6 +23,9 @@ export class TestDataserviceComponent extends AbstractPageComponent {
   private dataservice: Dataservice;
   private dataserviceService: DataserviceService;
   private pageLoadingState: LoadingState = LoadingState.LOADED_VALID;
+  private selectedSvcViews: Table[] = [];
+  private allSvcViews: Table[] = [];
+  private quickLookQueryText: string;
 
   constructor( router: Router, route: ActivatedRoute, dataserviceService: DataserviceService, logger: LoggerService ) {
     super(route, logger);
@@ -30,6 +34,11 @@ export class TestDataserviceComponent extends AbstractPageComponent {
 
   public loadAsyncPageData(): void {
     this.dataservice = this.dataserviceService.getSelectedDataservice();
+    this.allSvcViews = this.dataserviceService.getSelectedDataserviceViews();
+    this.selectedSvcViews = [];
+    this.selectedSvcViews.push(this.allSvcViews[0]);
+    const viewName = this.selectedSvcViews[0].getName();
+    this.quickLookQueryText = "SELECT * FROM " + viewName + ";";
   }
 
   /**
@@ -47,10 +56,23 @@ export class TestDataserviceComponent extends AbstractPageComponent {
   }
 
   /**
-   * Determine if page has loaded but was not successful
+   * Accessor for all available service views
    */
-  public get pageLoadedInvalid( ): boolean {
-    return this.pageLoadingState === LoadingState.LOADED_INVALID;
+  public get allServiceViews( ): Table[] {
+    return this.allSvcViews;
   }
 
+  /**
+   * Accessor for selected service view
+   */
+  public get selectedViews( ): Table[] {
+    return this.selectedSvcViews;
+  }
+
+  /**
+   * @returns {string} the quick look service name
+   */
+  public get quickLookSql(): string {
+    return this.quickLookQueryText;
+  }
 }


### PR DESCRIPTION
Adds support in the SqlControl component for multiple dataservice views, so that we will be prepared when they are available.
- In DataserviceService, adds function to get all views for the selected dataservice.  This will need updating to support multiple views when available.
- Reworked the SqlControl component, to display the list of available views.  When displayed the first view is selected.  The component can be set to 'quicklook' which means that the list will be shorter, and the user will not be able to edit the default sql.
- modified the users of SqlControl component (TestDataservice page and Dataservices page) so that they set the required inputs for the SqlControl
- other minor css cleanup