### PR TITLE
Add a way to select the connection used when selecting tables of the dataservice

### DIFF
--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.css
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.css
@@ -3,3 +3,45 @@
   font-size: 67px;
   line-height: 67px;
 }
+
+.wiz-review-table-checked:before {
+  display: inline-block;
+  margin-bottom: 0;
+  margin-left: 4px;
+  margin-right: 4px;
+  margin-top: 0;
+  font-family: "FontAwesome";
+  content: "\f046";
+  color: green;
+}
+
+.wiz-review-table-checked {
+  margin: 4px;
+}
+
+.wiz-review-table-unchecked:before {
+  display: inline-block;
+  margin-bottom: 0;
+  margin-left: 4px;
+  margin-right: 4px;
+  margin-top: 0;
+  font-family: "FontAwesome";
+  content: "\f096";
+}
+
+.wiz-review-table-unchecked {
+  margin: 4px;
+}
+
+.wiz-review-tables {
+  height: 200px;
+  width: 300px;
+  margin-left: 20px;
+  padding-left: 4px;
+  overflow: scroll;
+  white-space: nowrap;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 2px;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+}

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
@@ -7,6 +7,19 @@
   <!-- Step 1 : Table Selection -->
   <!-- ------------------------- -->
   <pfng-wizard-step [config]="step1Config">
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="form-group">
+          <pfng-inline-notification
+            [header]="connectionNotificationHeader"
+            [message]="connectionNotificationMessage"
+            [dismissable]="connectionNotificationDismissable"
+            [type]="connectionNotificationType">
+          </pfng-inline-notification>
+        </div>
+      </div>
+    </div>
+
     <h3><i>{{ step1InstructionMessage }}</i></h3>
     <br>
     <app-connection-table-selector (selectedTableListUpdated)="updatePage1ValidStatus()"></app-connection-table-selector>
@@ -21,7 +34,7 @@
       <br>
       <form [formGroup]=basicPropertyForm class="form-horizontal">
         <div [ngClass]="nameValid ? 'form-group' : 'form-group has-error'">
-          <label class="col-sm-2 control-label">Name</label>
+          <label class="col-sm-2 control-label required-pf">Name</label>
           <div class="col-sm-5">
             <input class="form-control" formControlName="name" title="">
             <div class="help-block" *ngIf="!nameValid">{{ nameValidationError }}</div>
@@ -33,11 +46,30 @@
             <input class="form-control" formControlName="description" title="">
           </div>
         </div>
-        <div class="form-group">
-          <label class="col-sm-2 control-label">Selected Tables:</label>
+        <div [ngClass]="hasSelectedConnection() ? 'form-group' : 'form-group has-error'">
+          <label class="col-sm-2 control-label required-pf"
+                 data-toggle="tooltip"
+                 data-placement="right"
+                 title="Select the connection whose tables will be included in the dataservice">
+            Connection
+          </label>
           <div class="col-sm-5">
-            <div *ngFor="let table of dataserviceSourceTables">
-              <label>[ {{ table.getConnection().getId() }} ] {{ table.getName() }}</label>
+            <select ([ngModel])="selectedConnection" (change)="selectedConnectionChanged($event)">
+              <option disabled selected value [ngValue]="emptyConnection">{{ emptyConnection.getId() }}</option>
+              <option *ngFor="let connection of sourceTableConnections"
+                      [ngValue]="connection">
+                {{ connection.getId() }}
+              </option>
+            </select>
+            <div class="help-block" *ngIf="!hasSelectedConnection()">{{ selectConnectionErrorMsg }}</div>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Included Tables</label>
+          <div class="col-sm-5 wiz-review-tables">
+            <div [ngClass]="shouldCheck(table) ? 'wiz-review-table-checked' : 'wiz-review-table-unchecked'"
+                 *ngFor="let table of dataserviceSourceTables">
+                {{ table.getName() }} ( {{ table.getConnection().getId() }} <span class="fa fa-plug"></span> )
             </div>
           </div>
         </div>

--- a/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.ts
+++ b/src/main/ngapp/src/app/dataservices/jdbc-table-selector/jdbc-table-selector.component.ts
@@ -490,6 +490,7 @@ export class JdbcTableSelectorComponent implements OnInit, TableSelector {
     // Load the table names for the selected Connection and Schema
     this.tables = [];
     this.filteredTables = [];
+    this.selectedAllRows = false;
     this.tableLoadingState = LoadingState.LOADING;
     const self = this;
     this.connectionService
@@ -517,11 +518,14 @@ export class JdbcTableSelectorComponent implements OnInit, TableSelector {
   }
 
   private setInitialTableSelections(): void {
+    let enableSelectAll = true;
+
     for ( const table of this.tables ) {
       // const catName = table.getCatalogName();
       // const schemaName = table.getSchemaName();
       const tableName = table.getName();
       const connName = table.getConnection().getId();
+
       for ( const initialTable of this.wizardService.getWizardSelectedTables() ) {
         // const iCatName = initialTable.getCatalogName();
         // const iSchemaName = initialTable.getSchemaName();
@@ -532,7 +536,13 @@ export class JdbcTableSelectorComponent implements OnInit, TableSelector {
           break;
         }
       }
+
+      if ( !table.selected ) {
+        enableSelectAll = false;
+      }
     }
+
+    this.selectedAllRows = enableSelectAll;
   }
 
 }


### PR DESCRIPTION
- changed step 2a of dataservice wizard to allow user to select the connection
- added a inline notification on step 1 of the dataservice wizard alerting user that multi-source is not yet supported
- fixed a bug in JdbcTableSelectorComponent where the table header checkbox did not have the correct state