### PR TITLE
TEIIDTOOLS-323 Dataservice Multi-view support

### DIFF
--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
@@ -285,7 +285,7 @@ export class AddConnectionWizardComponent implements OnInit {
 
     const self = this;
     this.connectionService
-      .createConnection(connection)
+      .createAndDeployConnection(connection)
       .subscribe(
         (wasSuccess) => {
           self.createComplete = true;

--- a/src/main/ngapp/src/app/connections/shared/connections-constants.ts
+++ b/src/main/ngapp/src/app/connections/shared/connections-constants.ts
@@ -17,6 +17,9 @@ export class ConnectionsConstants {
   public static readonly connectionsRootRoute = "connections";
   public static readonly connectionsRootPath = "/" + ConnectionsConstants.connectionsRootRoute;
 
+  public static readonly connectionRootRoute = "connection";
+  public static readonly connectionRootPath = "/" + ConnectionsConstants.connectionRootRoute;
+
   public static readonly addConnectionRoute = ConnectionsConstants.connectionsRootRoute + "/add-connection";
   public static readonly addConnectionPath = ConnectionsConstants.connectionsRootPath + "/add-connection";
 

--- a/src/main/ngapp/src/app/core/app-settings.service.ts
+++ b/src/main/ngapp/src/app/core/app-settings.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Injectable, OnInit } from "@angular/core";
+import { Injectable } from "@angular/core";
 import { Headers, Http, RequestOptions, Response } from "@angular/http";
 import { LoggerService } from "@core/logger.service";
 import { environment } from "@environments/environment";
@@ -24,7 +24,7 @@ import { Observable } from "rxjs/Observable";
 import { ErrorObservable } from "rxjs/observable/ErrorObservable";
 
 @Injectable()
-export class AppSettingsService implements OnInit {
+export class AppSettingsService {
 
   private static readonly userProfileUrl = environment.komodoServiceUrl + "/userProfile";
 
@@ -61,9 +61,11 @@ export class AppSettingsService implements OnInit {
     this.gitRepoProperties.set(this.GIT_REPO_PASSWORD_KEY, "MY_PASS");
     this.gitRepoProperties.set(this.GIT_REPO_AUTHOR_NAME_KEY, "MY_USER");
     this.gitRepoProperties.set(this.GIT_REPO_AUTHOR_EMAIL_KEY, "USER@SOMEWHERE.COM");
+
+    this.initUserProfile();
   }
 
-  public ngOnInit(): void {
+  public initUserProfile(): void {
     //
     // Do a call to fetch the user profile on init of service.
     // The fetchProfile method returns an observable

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
@@ -287,7 +287,7 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
 
     const self = this;
     this.vdbService
-      .deployVdbForTable(this.tableSelector.getSelectedTables()[0])
+      .deployVdbForTables(this.tableSelector.getSelectedTables())
       .subscribe(
         (wasSuccess) => {
           // Deployment succeeded - wait for source vdb to become active
@@ -344,9 +344,9 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
 
     if (status.isActive()) {
       if (this.wizardService.isEdit()) {
-        this.updateDataserviceForSingleTable();
+        this.updateDataserviceForSingleSourceTables();
       } else {
-        this.createDataserviceForSingleTable();
+        this.createDataserviceForSingleSourceTables();
       }
     } else if (status.isFailed()) {
       this.setFinalPageComplete(false);
@@ -487,19 +487,16 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
   }
 
   /*
-   * Create the Dataservice for the selected source table.  This is invoked
+   * Create the Dataservice for the selected single source tables.  This is invoked
    * only after the source VDB has successfully deployed.
    */
-  private createDataserviceForSingleTable(): void {
-    const dataservice: NewDataservice = new NewDataservice();
-
+  private createDataserviceForSingleSourceTables(): void {
     // Dataservice basic properties from step 1
-    dataservice.setId(this.dataserviceName);
-    dataservice.setDescription(this.dataserviceDescription);
+    const dataservice: NewDataservice = this.dataserviceService.newDataserviceInstance(this.dataserviceName, this.dataserviceDescription);
 
     const self = this;
     this.dataserviceService
-      .createDataserviceForSingleTable(dataservice, this.tableSelector.getSelectedTables()[0])
+      .createDataserviceForSingleSourceTables(dataservice, this.tableSelector.getSelectedTables())
       .subscribe(
         (wasSuccess) => {
           self.setFinalPageComplete(wasSuccess);
@@ -513,19 +510,16 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Update the selected Dataservice for the selected source table.  This is invoked
+   * Update the selected Dataservice for the selected single source tables.  This is invoked
    * only after the source VDB has successfully deployed.
    */
-  private updateDataserviceForSingleTable(): void {
-    const dataservice: NewDataservice = new NewDataservice();
-
+  private updateDataserviceForSingleSourceTables(): void {
     // Dataservice basic properties from step 1
-    dataservice.setId(this.dataserviceName);
-    dataservice.setDescription(this.dataserviceDescription);
+    const dataservice: NewDataservice = this.dataserviceService.newDataserviceInstance(this.dataserviceName, this.dataserviceDescription);
 
     const self = this;
     this.dataserviceService
-      .updateDataserviceForSingleTable(dataservice, this.tableSelector.getSelectedTables()[0])
+      .updateDataserviceForSingleSourceTables(dataservice, this.tableSelector.getSelectedTables())
       .subscribe(
         (wasSuccess) => {
           self.setFinalPageComplete(wasSuccess);

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
@@ -25,7 +25,7 @@ export class Dataservice implements Identifiable< string > {
   private tko__description: string;
   private serviceVdbName: string;
   private serviceVdbVersion: string;
-  private serviceView: string;
+  private serviceViews: string[];
   private serviceViewModel: string;
   private serviceViewTables: string[];
   private deploymentState: DeploymentState = DeploymentState.LOADING;
@@ -112,10 +112,10 @@ export class Dataservice implements Identifiable< string > {
   }
 
   /**
-   * @returns {string} the dataservice view name (can be null)
+   * @returns {string[]} the dataservice view names (can be null)
    */
-  public getServiceViewName(): string {
-    return this.serviceView;
+  public getServiceViewNames(): string[] {
+    return this.serviceViews;
   }
 
   /**
@@ -215,10 +215,10 @@ export class Dataservice implements Identifiable< string > {
   }
 
   /**
-   * @param {string} viewName the dataservice view name
+   * @param {string[]} viewNames the dataservice view names
    */
-  public setServiceViewName( viewName: string ): void {
-    this.serviceView = viewName;
+  public setServiceViewNames( viewNames: string[] ): void {
+    this.serviceViews = viewNames;
   }
 
   /**
@@ -249,7 +249,7 @@ export class Dataservice implements Identifiable< string > {
       tko__description: this.tko__description,
       serviceVdbName: this.serviceVdbName,
       serviceVdbVersion: this.serviceVdbVersion,
-      serviceView: this.serviceView,
+      serviceViews: this.serviceViews,
       serviceViewModel: this.serviceViewModel,
       serviceViewTables: this.serviceViewTables
     };

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -46,15 +46,17 @@ export class MockDataserviceService extends DataserviceService {
     this.serv1.setId("serv1");
     this.serv1.setServiceViewTables(["table1", "table2"]);
     this.serv1.setServiceViewModel("viewModel");
-    this.serv1.setServiceViewName("views");
+    const viewNames: string[] = [];
+    viewNames.push("views");
+    this.serv1.setServiceViewNames(viewNames);
     this.serv2.setId("serv2");
     this.serv2.setServiceViewTables(["table1", "table2"]);
     this.serv2.setServiceViewModel("viewModel");
-    this.serv2.setServiceViewName("views");
+    this.serv2.setServiceViewNames(viewNames);
     this.serv3.setId("serv3");
     this.serv3.setServiceViewTables(["table1", "table2"]);
     this.serv3.setServiceViewModel("viewModel");
-    this.serv3.setServiceViewName("views");
+    this.serv3.setServiceViewNames(viewNames);
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
@@ -153,10 +153,10 @@ export class MockVdbService extends VdbService {
 
   /**
    * Create and deploy a VDB for the provided table
-   * @param {Table} table
+   * @param {Table[]} tables
    * @returns {Observable<boolean>}
    */
-  public deployVdbForTable(table: Table): Observable<boolean> {
+  public deployVdbForTables(tables: Table[]): Observable<boolean> {
     return Observable.of(true);
   }
 

--- a/src/main/ngapp/src/app/dataservices/shared/new-dataservice.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/new-dataservice.model.ts
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ReflectiveInjector } from "@angular/core";
-import { AppSettingsService } from "@core/app-settings.service";
 
 export class NewDataservice {
 
@@ -23,15 +21,14 @@ export class NewDataservice {
   private keng__dataPath: string;
   private keng__kType: string;
   private tko__description: string;
-  private appSettings: AppSettingsService;
+  private workspacePath: string;
 
   /**
    * Constructor
    */
-  constructor( ) {
+  constructor(workspacePath: string) {
     this.keng__kType = "Dataservice";
-    const injector = ReflectiveInjector.resolveAndCreate([AppSettingsService]);
-    this.appSettings = injector.get(AppSettingsService);
+    this.workspacePath = workspacePath;
   }
 
   /**
@@ -53,7 +50,7 @@ export class NewDataservice {
    */
   public setId( name: string ): void {
     this.keng__id = name;
-    this.keng__dataPath = this.appSettings.getKomodoUserWorkspacePath() + "/" + name;
+    this.keng__dataPath = this.workspacePath + "/" + name;
   }
 
   /**
@@ -63,7 +60,7 @@ export class NewDataservice {
     this.tko__description = description ? description : null;
   }
 
-  // overrides toJSON - we do not want the appSettings
+  // overrides toJSON - we do not want the workspace path
   public toJSON(): {} {
     return {
       keng__id: this.keng__id,

--- a/src/main/ngapp/src/app/dataservices/shared/vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb.service.ts
@@ -283,12 +283,14 @@ export class VdbService extends ApiService {
   }
 
   /**
-   * Create and deploy a VDB for the provided table
-   * @param {Table} table
+   * Create and deploy a VDB for the provided tables.  Currently we require all tables to
+   * be from the same connection source.
+   * @param {Table[]} tables
    * @returns {Observable<boolean>}
    */
-  public deployVdbForTable(table: Table): Observable<boolean> {
-    const connection: Connection = table.getConnection();
+  public deployVdbForTables(tables: Table[]): Observable<boolean> {
+    // Currently requiring all tables from same connection
+    const connection: Connection = tables[0].getConnection();
 
     // VDB to create
     const vdb = new Vdb();
@@ -306,22 +308,21 @@ export class VdbService extends ApiService {
     vdbModel.setId(connName);
     vdbModel.setDataPath(vdbPath + "/" + connName);
     vdbModel.setModelType("PHYSICAL");
-    // Filter values for the model
-    let catName = table.getCatalogName();
-    let schemaName = table.getSchemaName();
-    // let tableName = table.getName();
-    catName = (!catName || catName.length < 1) ? "%" : catName;
-    schemaName = (!schemaName || schemaName.length < 1) ? "%" : schemaName;
-    // tableName = (!tableName || tableName.length < 1) ? "%" : tableName;
+
+    // TODO: Narrow the filters.  Currently fetches entire schema.  (Schema generation will be changing anyway)
+    const catNamePattern = "%";
+    const schemaNamePattern = "%";
+    const tableNamePattern = "%";
+
     // Set the importer properties for the physical model
     const props: NameValue[] = [];
     props.push(new NameValue("importer.TableTypes", "TABLE"));
     props.push(new NameValue("importer.UseFullSchemaName", "false"));
     props.push(new NameValue("importer.UseQualifiedName", "false"));
     props.push(new NameValue("importer.UseCatalogName", "false"));
-    props.push(new NameValue("importer.catalog", catName));
-    props.push(new NameValue("importer.schemaPattern", schemaName));
-    props.push(new NameValue("importer.tableNamePattern", "%"));  // TODO improve tablePattern when possible
+    props.push(new NameValue("importer.catalog", catNamePattern));
+    props.push(new NameValue("importer.schemaPattern", schemaNamePattern));
+    props.push(new NameValue("importer.tableNamePattern", tableNamePattern));
     vdbModel.setProperties(props);
 
     // VdbModelSource to create


### PR DESCRIPTION
TEIIDTOOLS-323
(This PR has a companion teiid-komodo PR)
- modifies Dataservice model to store multiple view names for the serve
- modifies Rest calls to use the new teiid-komodo rest service
- AppSettingService moved userProfile init into the constructor
- ConnectionService now deploys the connection to teiid when the connection is created.
- removed reflective injection of AppSettings service in NewDataservice model.  Now passed in the constructor.  Reorganized couple other related usages.
