### PR TITLE
Accept project name as parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules/
 
 # IDEs and editors
 /.idea
+*.iml
 .project
 .classpath
 .c9/

--- a/openshift/beetle-studio-s2i.json
+++ b/openshift/beetle-studio-s2i.json
@@ -20,6 +20,12 @@
     },
     "parameters": [
         {
+            "description":"Namespace for the application. Note: The namespace is required for creating proper RoleBindings. Specifying wrong namespace will prevent cluster from forming. This should be same as your project name.",
+            "name":"NAMESPACE",
+            "required":true,
+            "value":"beetle-studio"
+        },
+        {
             "description": "The location url of the beetle-studio source repository",
             "displayName": "BeETLe-Studio Source URL",
             "name": "BEETLE_GIT_URL",
@@ -851,7 +857,7 @@
                                     "--skip-auth-preflight",
                                     "--openshift-ca=/etc/pki/tls/certs/ca-bundle.crt",
                                     "--openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-                                    "--scope=user:info user:check-access role:admin:beetle-studio:! role:cluster-admin:beetle-studio:!"
+                                    "--scope=user:info user:check-access role:admin:${NAMESPACE}:! role:cluster-admin:${NAMESPACE}:!"
                                 ],
                                 "volumeMounts": [
                                     {


### PR DESCRIPTION
The template will accept namespace as parameter to be able to automatically create proper security roles

Without this applied, user has to edit the template manually and change the hardcoded namespace before deploying the template if he is deploying it to a project with different name than beetle-studio.

The DAS template already does this: https://github.com/teiid/data-access-service-templates/blob/8921387d43ea3c584a8bd8467845a5146b51d565/das/data-access-service.json#L176