### PR TITLE
template now utilizes namespace parameter

### DIFF
--- a/openshift/beetle-studio-s2i.json
+++ b/openshift/beetle-studio-s2i.json
@@ -711,7 +711,7 @@
                                     },
                                     {
                                     	"name": "SWARM_JAR_ARGS",
-                                    	"value": "-DNAMESPACE=beetle-studio -Dkomodo.user=${PERSISTENCE_STORAGE_USER} -Dkomodo.password=${PERSISTENCE_STORAGE_PASSWORD} -Dkomodo.repositoryPersistenceHost=vdb-builder-persistence"
+                                    	"value": "-DNAMESPACE=${NAMESPACE} -Dkomodo.user=${PERSISTENCE_STORAGE_USER} -Dkomodo.password=${PERSISTENCE_STORAGE_PASSWORD} -Dkomodo.repositoryPersistenceHost=vdb-builder-persistence"
                                     }
                                 ],
                                 "livenessProbe":{


### PR DESCRIPTION
changed template the utilize the parameterized NAMESPACE.  Service sources were not being found because namespace was hardcoded to beetle-studio instead of the namespace parameter in the teiid-komodo startup.