### PR TITLE
TEIIDTOOLS-371 Connection schema work

### DIFF
--- a/src/main/ngapp/src/app/activities/add-activity-wizard/add-activity-wizard.component.spec.ts
+++ b/src/main/ngapp/src/app/activities/add-activity-wizard/add-activity-wizard.component.spec.ts
@@ -9,6 +9,9 @@ import { MockConnectionService } from "@connections/shared/mock-connection.servi
 import { AppSettingsService } from "@core/app-settings.service";
 import { CoreModule } from "@core/core.module";
 import { MockAppSettingsService } from "@core/mock-app-settings.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { PropertyFormPropertyComponent } from "@shared/property-form/property-form-property/property-form-property.component";
 import { PropertyFormComponent } from "@shared/property-form/property-form.component";
 import { PatternFlyNgModule } from "patternfly-ng";
@@ -23,9 +26,11 @@ describe("AddActivityWizardComponent", () => {
       imports: [ CoreModule, FormsModule, PatternFlyNgModule, ReactiveFormsModule, RouterTestingModule ],
       declarations: [ AddActivityWizardComponent, PropertyFormComponent, PropertyFormPropertyComponent ],
       providers: [
+        NotifierService,
         { provide: AppSettingsService, useClass: MockAppSettingsService },
         { provide: ActivityService, useClass: MockActivityService },
-        { provide: ConnectionService, useClass: MockConnectionService }
+        { provide: ConnectionService, useClass: MockConnectionService },
+        { provide: VdbService, useClass: MockVdbService }
       ]
     })
       .compileComponents().then(() => {

--- a/src/main/ngapp/src/app/activities/add-activity-wizard/add-activity-wizard.component.ts
+++ b/src/main/ngapp/src/app/activities/add-activity-wizard/add-activity-wizard.component.ts
@@ -127,9 +127,13 @@ export class AddActivityWizardComponent implements OnInit {
     this.connectionsLoadSuccess = false;
     const self = this;
     this.connectionService
-      .getAllConnections()
+      .getConnections(true, false)
       .subscribe(
-        (conns) => {
+        (connectionSummaries) => {
+          const conns = [];
+          for ( const connectionSummary of connectionSummaries ) {
+            conns.push(connectionSummary.getConnection());
+          }
           self.allConnections = conns;
           self.connectionsLoading = false;
           self.connectionsLoadSuccess = true;

--- a/src/main/ngapp/src/app/activities/add-activity/add-activity.component.spec.ts
+++ b/src/main/ngapp/src/app/activities/add-activity/add-activity.component.spec.ts
@@ -10,6 +10,9 @@ import { MockConnectionService } from "@connections/shared/mock-connection.servi
 import { AppSettingsService } from "@core/app-settings.service";
 import { CoreModule } from "@core/core.module";
 import { MockAppSettingsService } from "@core/mock-app-settings.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { SharedModule } from "@shared/shared.module";
 import { PatternFlyNgModule } from "patternfly-ng";
 import { AddActivityComponent } from "./add-activity.component";
@@ -23,9 +26,11 @@ describe("AddActivityComponent", () => {
       imports: [ CoreModule, PatternFlyNgModule, FormsModule, ReactiveFormsModule, RouterTestingModule, SharedModule ],
       declarations: [ AddActivityComponent, AddActivityWizardComponent ],
       providers: [
+        NotifierService,
         { provide: ActivityService, useClass: MockActivityService },
         { provide: AppSettingsService, useClass: MockAppSettingsService },
-        { provide: ConnectionService, useClass: MockConnectionService }
+        { provide: ConnectionService, useClass: MockConnectionService },
+        { provide: VdbService, useClass: MockVdbService }
       ]
     })
       .compileComponents().then(() => {

--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.spec.ts
@@ -9,6 +9,9 @@ import { MockConnectionService } from "@connections/shared/mock-connection.servi
 import { AppSettingsService } from "@core/app-settings.service";
 import { CoreModule } from "@core/core.module";
 import { MockAppSettingsService } from "@core/mock-app-settings.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { WizardService } from "@dataservices/shared/wizard.service";
 import { PropertyFormPropertyComponent } from "@shared/property-form/property-form-property/property-form-property.component";
 import { PropertyFormComponent } from "@shared/property-form/property-form.component";
@@ -28,6 +31,8 @@ describe("AddConnectionWizardComponent", () => {
         WizardService,
         { provide: AppSettingsService, useClass: MockAppSettingsService },
         { provide: ConnectionService, useClass: MockConnectionService },
+        NotifierService,
+        { provide: VdbService, useClass: MockVdbService }
       ]
     })
     .compileComponents().then(() => {

--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
@@ -367,9 +367,9 @@ export class AddConnectionWizardComponent implements OnInit {
 
     const self = this;
     if (this.wizardService.isEdit()) {
-      this.updateAndBindConnection(connection);
+      this.updateDeployConnection(connection);
     } else {
-      this.createAndBindConnection(connection);
+      this.createDeployConnection(connection);
     }
   }
 
@@ -508,13 +508,14 @@ export class AddConnectionWizardComponent implements OnInit {
   }
 
   /**
-   * Creates the connection ensuring it is bound
+   * Creates the workspace connection, binds to serviceCatalogSource,
+   * and deploys a corresponding connection VDB to teiid.
    * @param {Connection} connection the new connection
    */
-  private createAndBindConnection(connection: NewConnection): void {
+  private createDeployConnection(connection: NewConnection): void {
     const self = this;
     this.connectionService
-      .createAndBindConnection(connection)
+      .createDeployConnection(connection)
       .subscribe(
         (wasSuccess) => {
           self.setFinalPageComplete(wasSuccess);
@@ -528,13 +529,14 @@ export class AddConnectionWizardComponent implements OnInit {
   }
 
   /**
-   * Updates the connection ensuring it is bound
+   * Updates the workspace connection, binds to serviceCatalogSource,
+   * and re-deploys the corresponding connection VDB to teiid.
    * @param {Connection} connection the new connection
    */
-  private updateAndBindConnection(connection: NewConnection): void {
+  private updateDeployConnection(connection: NewConnection): void {
     const self = this;
     this.connectionService
-      .updateAndBindConnection(connection)
+      .updateDeployConnection(connection)
       .subscribe(
         (wasSuccess) => {
           self.setFinalPageComplete(wasSuccess);

--- a/src/main/ngapp/src/app/connections/add-connection/add-connection.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/add-connection/add-connection.component.spec.ts
@@ -10,6 +10,9 @@ import { MockConnectionService } from "@connections/shared/mock-connection.servi
 import { AppSettingsService } from "@core/app-settings.service";
 import { CoreModule } from "@core/core.module";
 import { MockAppSettingsService } from "@core/mock-app-settings.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { WizardService } from "@dataservices/shared/wizard.service";
 import { SharedModule } from "@shared/shared.module";
 import { PatternFlyNgModule } from "patternfly-ng";
@@ -25,9 +28,11 @@ describe("AddConnectionComponent", () => {
       declarations: [ AddConnectionComponent, AddConnectionWizardComponent,
                       ConnectionTypeCardComponent, ConnectionTypeCardsComponent ],
       providers: [
+        NotifierService,
         WizardService,
         { provide: AppSettingsService, useClass: MockAppSettingsService },
         { provide: ConnectionService, useClass: MockConnectionService },
+        { provide: VdbService, useClass: MockVdbService }
       ]
     })
     .compileComponents().then(() => {

--- a/src/main/ngapp/src/app/connections/connections-cards/connection-card/connection-card.component.css
+++ b/src/main/ngapp/src/app/connections/connections-cards/connection-card/connection-card.component.css
@@ -1,0 +1,23 @@
+.card-toolbar .secondary-action[title="Activate"]:before {
+  color: var(--card-action-icon-color);
+  content: "\f1eb";
+  font-family: "FontAwesome";
+}
+
+.object-card .list-pf,
+.object-card-selected .list-pf {
+  border: none;
+}
+
+.object-card .list-pf-item,
+.object-card-selected .list-pf-item {
+  border: none;
+}
+
+.object-card .list-pf-item:hover {
+  background-color: transparent;
+}
+
+.object-card-selected .list-pf-item:hover {
+  background-color: transparent;
+}

--- a/src/main/ngapp/src/app/connections/connections-cards/connection-card/connection-card.component.html
+++ b/src/main/ngapp/src/app/connections/connections-cards/connection-card/connection-card.component.html
@@ -11,17 +11,49 @@
                      (onActionSelect)="handleAction($event)">
         </pfng-action>
       </div>
-      <span class="pull-right fa pficon-connected card-action-icon"
-            (click)="onClick(pingEvent)"
+      <span class="pull-left fa fa-check-circle-o fa-2x card-action-icon"
+            style="color:green;"
+            *ngIf="connection.schemaActive"
             data-toggle="tooltip"
             data-placement="right"
-            title="Determine if accessible">
+            title="Active">
       </span>
-      <span class="pull-right fa fa-edit card-action-icon"
+      <span class="pull-left fa fa-times-circle-o fa-2x card-action-icon"
+            style="color:red;"
+            *ngIf="connection.schemaFailed"
+            data-toggle="tooltip"
+            data-placement="right"
+            title="Failed to activate">
+      </span>
+      <span class="pull-left fa fa-exclamation-triangle fa-2x card-action-icon"
+            style="color:orange;"
+            *ngIf="connection.schemaInactive"
+            data-toggle="tooltip"
+            data-placement="right"
+            title="Inactive">
+      </span>
+      <span class="pull-left fa fa-times-circle-o fa-2x card-action-icon"
+            style="color:red;"
+            *ngIf="connection.schemaNotDeployed"
+            data-toggle="tooltip"
+            data-placement="right"
+            title="Inactive">
+      </span>
+      <span class="pull-left fa fa-spinner fa-pulse fa-2x card-action-icon"
+            *ngIf="connection.schemaLoading">
+      </span>
+      <span *ngIf="!connection.schemaLoading"
+            class="pull-right fa fa-edit card-action-icon"
             (click)="onClick(editEvent)"
             data-toggle="tooltip"
             data-placement="right"
-            title="Edit properties">
+            title="Edit">
+      </span>
+      <span *ngIf="connection.schemaLoading"
+            class="pull-right fa fa-edit card-action-icon-disabled"
+            data-toggle="tooltip"
+            data-placement="right"
+            title="Edit">
       </span>
     </div>
     <div class="row card-pf-title text-center object-card-title">

--- a/src/main/ngapp/src/app/connections/connections-cards/connection-card/connection-card.component.ts
+++ b/src/main/ngapp/src/app/connections/connections-cards/connection-card/connection-card.component.ts
@@ -29,12 +29,11 @@ import { Action, ActionConfig, CardAction, CardConfig, ListConfig } from "patter
 })
 export class ConnectionCardComponent implements DoCheck, OnInit {
 
+  public static readonly activateConnectionEvent = "activate";
   public static readonly deleteConnectionEvent = "delete";
   public static readonly editConnectionEvent = "edit";
-  public static readonly pingConnectionEvent = "ping";
 
   public readonly editEvent = ConnectionCardComponent.editConnectionEvent;
-  public readonly pingEvent = ConnectionCardComponent.pingConnectionEvent;
 
   @Input() public connection: Connection;
   @Input() public selectedConnections: Connection[];
@@ -46,7 +45,12 @@ export class ConnectionCardComponent implements DoCheck, OnInit {
   public listConfig: ListConfig;
   public showDetails = false;
 
+  private readonly activateActionId = "activate";
+  private readonly activateActionIndex = 0; // index in moreActions
   private readonly deleteActionId = "delete";
+  private readonly deleteActionIndex = 1; // index in moreActions
+
+  private isLoading = false;
   private logger: LoggerService;
 
   constructor( logger: LoggerService ) {
@@ -62,7 +66,9 @@ export class ConnectionCardComponent implements DoCheck, OnInit {
    * @param {Action} action the action that was selected.
    */
   public handleAction( action: Action ): void {
-    if ( action.id === this.deleteActionId ) {
+    if ( action.id === this.activateActionId ) {
+      this.onClick( ConnectionCardComponent.activateConnectionEvent);
+    } else if ( action.id === this.deleteActionId ) {
       this.onClick( ConnectionCardComponent.deleteConnectionEvent );
     } else {
       this.logger.error( "Action '" + action.id + "' not handled." );
@@ -77,6 +83,13 @@ export class ConnectionCardComponent implements DoCheck, OnInit {
   }
 
   public ngDoCheck(): void {
+    if ( this.isLoading !== this.connection.schemaLoading ) {
+      this.isLoading = this.connection.schemaLoading;
+
+      this.actionConfig.moreActions[ this.activateActionIndex ].disabled = this.isLoading;
+      this.actionConfig.moreActions[ this.deleteActionIndex ].disabled = this.isLoading;
+    }
+
     this.cardConfig.action.iconStyleClass = this.detailsIconStyle;
   }
 
@@ -88,11 +101,16 @@ export class ConnectionCardComponent implements DoCheck, OnInit {
       primaryActions: [
       ],
       moreActions: [
-          {
-            id: this.deleteActionId,
-            title: "Delete",
-            tooltip: "Delete the connection"
-          }
+        {
+          id: this.activateActionId,
+          title: "Activate",
+          tooltip: "Activate"
+        },
+        {
+          id: this.deleteActionId,
+          title: "Delete",
+          tooltip: "Delete"
+        }
       ]
     } as ActionConfig;
 

--- a/src/main/ngapp/src/app/connections/connections-cards/connections-cards.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/connections-cards/connections-cards.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ConnectionCardComponent } from "@connections/connections-cards/connection-card/connection-card.component";
 import { ConnectionsCardsComponent } from "@connections/connections-cards/connections-cards.component";
+import { LoggerService } from "@core/logger.service";
 import { PatternFlyNgModule } from "patternfly-ng";
 
 describe("ConnectionsCardsComponent", () => {
@@ -11,7 +12,8 @@ describe("ConnectionsCardsComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [ PatternFlyNgModule, RouterTestingModule ],
-      declarations: [ ConnectionCardComponent, ConnectionsCardsComponent ]
+      declarations: [ ConnectionCardComponent, ConnectionsCardsComponent ],
+      providers: [ LoggerService ]
     })
     .compileComponents().then(() => {
       // nothing to do

--- a/src/main/ngapp/src/app/connections/connections-cards/connections-cards.component.ts
+++ b/src/main/ngapp/src/app/connections/connections-cards/connections-cards.component.ts
@@ -18,6 +18,7 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { ConnectionCardComponent } from "@connections/connections-cards/connection-card/connection-card.component";
 import { Connection } from "@connections/shared/connection.model";
+import { LoggerService } from "@core/logger.service";
 
 @Component({
   moduleId: module.id,
@@ -32,15 +33,17 @@ export class ConnectionsCardsComponent {
 
   @Output() public connectionSelected: EventEmitter<Connection> = new EventEmitter<Connection>();
   @Output() public connectionDeselected: EventEmitter<Connection> = new EventEmitter<Connection>();
+  @Output() public activateConnection: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteConnection: EventEmitter<string> = new EventEmitter<string>();
   @Output() public editConnection: EventEmitter<string> = new EventEmitter<string>();
-  @Output() public pingConnection: EventEmitter<string> = new EventEmitter<string>();
+
+  public logger: LoggerService;
 
   /**
-   * Constructor.
+   * @param {LoggerService} logger the logging service
    */
-  constructor() {
-    // nothing to do
+  constructor( logger: LoggerService ) {
+    this.logger = logger;
   }
 
   public isSelected( connection: Connection ): boolean {
@@ -53,15 +56,14 @@ export class ConnectionsCardsComponent {
       case ConnectionCardComponent.deleteConnectionEvent:
         this.deleteConnection.emit( event.connectionName );
         break;
+      case ConnectionCardComponent.activateConnectionEvent:
+        this.activateConnection.emit( event.connectionName );
+        break;
       case ConnectionCardComponent.editConnectionEvent:
         this.editConnection.emit( event.connectionName );
         break;
-      case ConnectionCardComponent.pingConnectionEvent:
-        this.pingConnection.emit( event.connectionName );
-        break;
       default:
-        // TODO log this
-        // this.logger.error( "Unhandled event type of '" + event.eventType + "'" );
+        this.logger.error( "Unhandled event type of '" + event.eventType + "'" );
         break;
     }
   }

--- a/src/main/ngapp/src/app/connections/connections-list/connections-list.component.css
+++ b/src/main/ngapp/src/app/connections/connections-list/connections-list.component.css
@@ -1,3 +1,10 @@
+/* Adds an icon to the left of the activate action item in dropdown of kebab. */
+.object-list .secondary-action[title*="Activate"]:before {
+  color: var(--card-action-icon-color);
+  content: "\f1eb";
+  font-family: "FontAwesome";
+}
+
 .connection-details-properties {
   padding-left: 40px;
 }

--- a/src/main/ngapp/src/app/connections/connections-list/connections-list.component.html
+++ b/src/main/ngapp/src/app/connections/connections-list/connections-list.component.html
@@ -19,20 +19,25 @@
             </div>
             <div class="list-pf-content-wrapper">
               <div class="list-pf-main-content">
-                <a [routerLink]="[item.name]" (click)="onEditConnection(item.name)">{{ item.name }}</a>
+                <span class="pull-left pficon-ok" *ngIf="item.schemaActive"></span>
+                <span class="pull-left pficon-error-circle-o" *ngIf="item.schemaFailed"></span>
+                <span class="pull-left pficon-warning-triangle-o" *ngIf="item.schemaInactive"></span>
+                <span class="pull-left pficon-error-circle-o" *ngIf="item.schemaNotDeployed"></span>
+                <span class="pull-left fa fa-spinner fa-pulse" *ngIf="item.schemaLoading"></span>
+                <a class="object-name-link" [routerLink]="[item.name]" (click)="onEditConnection(item.name)">{{ item.name }}</a>
                 <div class="list-pf-description">{{ getDescription(item) }}</div>
               </div>
             </div>
           </ng-template>
           <ng-template #actionTemplate let-item="item" let-index="index">
             <pfng-action class="list-pf-actions"
-                         [config]="getActionConfig( item, editActionTemplate, pingActionTemplate, deleteActionTemplate )"
+                         [config]="getActionConfig( item, editActionTemplate, activateActionTemplate, deleteActionTemplate )"
                          (onActionSelect)="handleAction( $event, item )">
               <ng-template #editActionTemplate let-action="action">
                 <span class="fa fa-edit">&nbsp;</span>{{ action.title }}
               </ng-template>
-              <ng-template #pingActionTemplate let-action="action">
-                <span class="fa pficon-connected">&nbsp;</span>{{ action.title }}
+              <ng-template #activateActionTemplate let-action="action">
+                <span class="fa fa-wifi">&nbsp;</span>{{ action.title }}
               </ng-template>
               <ng-template #deleteActionTemplate let-action="action">
                 <span class="fa fa-trash-o">&nbsp;</span>{{ action.title }}

--- a/src/main/ngapp/src/app/connections/connections-list/connections-list.component.ts
+++ b/src/main/ngapp/src/app/connections/connections-list/connections-list.component.ts
@@ -34,16 +34,16 @@ export class ConnectionsListComponent implements OnInit {
 
   @Output() public connectionDeselected: EventEmitter<Connection> = new EventEmitter<Connection>();
   @Output() public connectionSelected: EventEmitter<Connection> = new EventEmitter<Connection>();
+  @Output() public activateConnection: EventEmitter<string> = new EventEmitter<string>();
   @Output() public deleteConnection: EventEmitter<string> = new EventEmitter<string>();
   @Output() public editConnection: EventEmitter<string> = new EventEmitter<string>();
-  @Output() public pingConnection: EventEmitter<string> = new EventEmitter<string>();
 
   public listConfig: ListConfig;
   private router: Router;
 
-  private readonly deleteActionId = "delecteActionId";
+  private readonly activateActionId = "activateActionId";
+  private readonly deleteActionId = "deleteActionId";
   private readonly editActionId = "editActionId";
-  private readonly pingActionId = "pingActionId";
 
   /**
    * Constructor.
@@ -72,35 +72,38 @@ export class ConnectionsListComponent implements OnInit {
    *
    * @param connection the connection represented by a row
    * @param editActionTemplate {TemplateRef} the edit action template
-   * @param pingActionTemplate {TemplateRef} the ping action template
+   * @param activateActionTemplate {TemplateRef} the activate action template
    * @param deleteActionTemplate {TemplateRef} the delete action template
    * @returns {ActionConfig} the actions configuration
    */
   public getActionConfig( connection: Connection,
                           editActionTemplate: TemplateRef< any >,
-                          pingActionTemplate: TemplateRef< any >,
+                          activateActionTemplate: TemplateRef< any >,
                           deleteActionTemplate: TemplateRef< any > ): ActionConfig {
     const actionConfig = {
       primaryActions: [
         {
+          disabled: connection.schemaLoading,
           id: this.editActionId,
           template: editActionTemplate,
           title: "Edit",
-          tooltip: "Edit properties"
-        },
-        {
-          id: this.pingActionId,
-          template: pingActionTemplate,
-          title: "Ping",
-          tooltip: "Determine if accessible"
+          tooltip: "Edit this connection"
         }
       ],
       moreActions: [
         {
+          disabled: connection.schemaLoading,
+          id: this.activateActionId,
+          template: activateActionTemplate,
+          title: "Activate",
+          tooltip: "Activate this connection"
+        },
+        {
+          disabled: connection.schemaLoading,
           id: this.deleteActionId,
           template: deleteActionTemplate,
           title: "Delete",
-          tooltip: "Delete the connection"
+          tooltip: "Delete this connection"
         }
       ],
       moreActionsDisabled: false,
@@ -133,10 +136,10 @@ export class ConnectionsListComponent implements OnInit {
     // now perform action
     if ( action.id === this.deleteActionId ) {
       this.onDeleteConnection( this.selectedConnections[ 0 ].getId() );
+    } else if ( action.id === this.activateActionId ) {
+      this.onActivateConnection( this.selectedConnections[ 0 ].getId() );
     } else if ( action.id === this.editActionId ) {
       this.onEditConnection( this.selectedConnections[ 0 ].getId() );
-    } else if ( action.id === this.pingActionId ) {
-      this.onPingConnection( this.selectedConnections[ 0 ].getId() );
     }
   }
 
@@ -145,6 +148,13 @@ export class ConnectionsListComponent implements OnInit {
    */
   public isSelected( connection: Connection ): boolean {
     return this.selectedConnections.indexOf( connection ) !== -1;
+  }
+
+  /**
+   * @param {string} connectionName the name of the connection to activate
+   */
+  public onActivateConnection(connectionName: string): void {
+    this.activateConnection.emit(connectionName);
   }
 
   /**
@@ -159,13 +169,6 @@ export class ConnectionsListComponent implements OnInit {
    */
   public onEditConnection( connectionName: string ): void {
     this.editConnection.emit( connectionName );
-  }
-
-  /**
-   * @param {string} connectionName the name of the connection to ping
-   */
-  public onPingConnection( connectionName: string ): void {
-    this.pingConnection.emit( connectionName );
   }
 
   /**

--- a/src/main/ngapp/src/app/connections/connections.component.html
+++ b/src/main/ngapp/src/app/connections/connections.component.html
@@ -41,7 +41,7 @@
           <div class="form-group">
             <pfng-empty-state
                 [config]="noConnectionsEmptyConfig"
-                (onActionSelect)="onNewConnection()"></pfng-empty-state>
+                (onActionSelect)="onNew()"></pfng-empty-state>
           </div>
         </div>
       </div>
@@ -66,16 +66,16 @@
         <app-connections-list *ngIf="isListLayout"
                               [connections]="filteredConnections"
                               [selectedConnections]="selectedConnections"
+                              (activateConnection)="onActivate($event)"
                               (editConnection)="onEdit($event)"
-                              (pingConnection)="onPing($event)"
                               (deleteConnection)="onDelete($event)"
                               (connectionSelected)="onSelected($event)"
                               (connectionDeselected)="onDeselected($event)"></app-connections-list>
         <app-connections-cards *ngIf="isCardLayout"
                                [connections]="filteredConnections"
                                [selectedConnections]="selectedConnections"
+                               (activateConnection)="onActivate($event)"
                                (editConnection)="onEdit($event)"
-                               (pingConnection)="onPing($event)"
                                (deleteConnection)="onDelete($event)"
                                (connectionSelected)="onSelected($event)"
                                (connectionDeselected)="onDeselected($event)"></app-connections-cards>

--- a/src/main/ngapp/src/app/connections/connections.component.spec.ts
+++ b/src/main/ngapp/src/app/connections/connections.component.spec.ts
@@ -13,6 +13,9 @@ import { MockConnectionService } from "@connections/shared/mock-connection.servi
 import { AppSettingsService } from "@core/app-settings.service";
 import { CoreModule } from "@core/core.module";
 import { MockAppSettingsService } from "@core/mock-app-settings.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { WizardService } from "@dataservices/shared/wizard.service";
 import { SharedModule } from "@shared/shared.module";
 import { ModalModule } from "ngx-bootstrap";
@@ -41,18 +44,13 @@ describe("ConnectionsComponent", () => {
         ConnectionsCardsComponent
       ],
       providers: [
-        WizardService
+        AppSettingsService,
+        NotifierService,
+        WizardService,
+        { provide: AppSettingsService, useClass: MockAppSettingsService },
+        { provide: ConnectionService, useClass: MockConnectionService },
+        { provide: VdbService, useClass: MockVdbService }
       ]
-    });
-
-    // use mock service
-    TestBed.overrideComponent( ConnectionsComponent, {
-      set: {
-        providers: [
-          { provide: AppSettingsService, useClass: MockAppSettingsService },
-          { provide: ConnectionService, useClass: MockConnectionService },
-        ]
-      }
     });
 
     fixture = TestBed.createComponent(ConnectionsComponent);
@@ -84,12 +82,12 @@ describe("ConnectionsComponent", () => {
     console.log("========== [ConnectionsComponent] should have Connections");
     // Check component object
     const connections = component.allConnections;
-    expect(connections.length).toEqual(4);
+    expect(connections.length).toEqual(3);
 
     // Check html has the same number of connection cards
     const cardDebugElems = fixture.debugElement.queryAll(By.css(".object-card"));
     expect(cardDebugElems).toBeDefined();
-    expect(cardDebugElems.length).toEqual(4);
+    expect(cardDebugElems.length).toEqual(3);
   });
 
   it("should have initial card layout", () => {

--- a/src/main/ngapp/src/app/connections/connections.module.ts
+++ b/src/main/ngapp/src/app/connections/connections.module.ts
@@ -33,6 +33,8 @@ import { MockConnectionService } from "@connections/shared/mock-connection.servi
 import { AppSettingsService } from "@core/app-settings.service";
 import { CoreModule } from "@core/core.module";
 import { LoggerService } from "@core/logger.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { environment } from "@environments/environment";
 import { SharedModule } from "@shared/shared.module";
 import { PatternFlyNgModule } from "patternfly-ng";
@@ -66,7 +68,7 @@ import { ConnectionTypeCardsComponent } from "./connection-type-cards/connection
     {
       provide: ConnectionService,
       useFactory: connectionServiceFactory,
-      deps: [ Http, AppSettingsService, LoggerService ],
+      deps: [ Http, VdbService, NotifierService, AppSettingsService, LoggerService ],
       multi: false
     },
     LoggerService
@@ -80,13 +82,25 @@ export class ConnectionsModule { }
  * A factory that produces the appropriate instande of the service based on current environment settings.
  *
  * @param {Http} http the HTTP service
+ * @param {VdbService} vdbService the vdb service
+ * @param {NotifierService} notifierService the notifier service
  * @param {AppSettingsService} appSettings the app settings service
  * @param {LoggerService} logger the logger
  * @returns {ConnectionService} the requested service
  */
 export function connectionServiceFactory( http: Http,
+                                          vdbService: VdbService,
+                                          notifierService: NotifierService,
                                           appSettings: AppSettingsService,
                                           logger: LoggerService ): ConnectionService {
-  return environment.production || !environment.uiDevMode ? new ConnectionService( http, appSettings, logger )
-                                                          : new MockConnectionService( http, appSettings, logger );
+  return environment.production || !environment.uiDevMode ? new ConnectionService( http,
+                                                                                   vdbService,
+                                                                                   notifierService,
+                                                                                   appSettings,
+                                                                                   logger )
+                                                          : new MockConnectionService( http,
+                                                                                       vdbService,
+                                                                                       notifierService,
+                                                                                       appSettings,
+                                                                                       logger );
 }

--- a/src/main/ngapp/src/app/connections/shared/connection.model.ts
+++ b/src/main/ngapp/src/app/connections/shared/connection.model.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { DeploymentState } from "@dataservices/shared/deployment-state.enum";
 import { Identifiable } from "@shared/identifiable";
 import { SortDirection } from "@shared/sort-direction.enum";
 
@@ -29,6 +30,7 @@ export class Connection implements Identifiable< string > {
   private dv__driverName: string;
   private dv__type: boolean;
   private keng__properties: object[] = [];
+  private schemaState: DeploymentState = DeploymentState.LOADING;
 
   /**
    * @param {Object} json the JSON representation of a Connection
@@ -154,6 +156,53 @@ export class Connection implements Identifiable< string > {
   }
 
   /**
+   * @returns {DeploymentState} the connection schema state
+   */
+  public getSchemaState(): DeploymentState {
+    return this.schemaState;
+  }
+
+  /**
+   * Accessor to determine if connection schema is active
+   * @returns {boolean} the connection schema active state
+   */
+  public get schemaActive(): boolean {
+    return this.schemaState === DeploymentState.ACTIVE;
+  }
+
+  /**
+   * Accessor to determine if connection schema is inactive
+   * @returns {boolean} the connection schema inactive state
+   */
+  public get schemaInactive(): boolean {
+    return this.schemaState === DeploymentState.INACTIVE;
+  }
+
+  /**
+   * Accessor to determine if connection schema is loading
+   * @returns {boolean} the connection schema loading state
+   */
+  public get schemaLoading(): boolean {
+    return this.schemaState === DeploymentState.LOADING;
+  }
+
+  /**
+   * Accessor to determine if connection schema is failed
+   * @returns {boolean} the connection schema failed state
+   */
+  public get schemaFailed(): boolean {
+    return this.schemaState === DeploymentState.FAILED;
+  }
+
+  /**
+   * Accessor to determine if connection schema is not deployed
+   * @returns {boolean} the connection schema not deployed state
+   */
+  public get schemaNotDeployed(): boolean {
+    return this.schemaState === DeploymentState.NOT_DEPLOYED;
+  }
+
+  /**
    * @param {string} driverName the connection driver name (optional)
    */
   public setDriverName( driverName?: string ): void {
@@ -194,6 +243,13 @@ export class Connection implements Identifiable< string > {
     prop.value = serviceCatalog;
 
     this.keng__properties.push(prop);
+  }
+
+  /**
+   * @param {DeploymentState} state the connection schema state
+   */
+  public setSchemaState( state: DeploymentState ): void {
+    this.schemaState = state;
   }
 
   /**

--- a/src/main/ngapp/src/app/connections/shared/connection.service.spec.ts
+++ b/src/main/ngapp/src/app/connections/shared/connection.service.spec.ts
@@ -3,12 +3,14 @@ import { HttpModule } from "@angular/http";
 import { ConnectionService } from "@connections/shared/connection.service";
 import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 
 describe("ConnectionService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpModule ],
-      providers: [AppSettingsService, ConnectionService, LoggerService]
+      providers: [AppSettingsService, ConnectionService, LoggerService, NotifierService, VdbService]
     });
   });
 

--- a/src/main/ngapp/src/app/connections/shared/connections-constants.ts
+++ b/src/main/ngapp/src/app/connections/shared/connections-constants.ts
@@ -36,6 +36,9 @@ export class ConnectionsConstants {
   public static readonly connectionTypeDescription_mongodb = "MongoDB database";
   public static readonly connectionTypeDescription_mariadb = "MariaDB database";
 
+  public static readonly includeConnectionParameter = "include-connection";
+  public static readonly includeSchemaStatusParameter = "include-schema-status";
+
   public static driverNamePropertyLabel = "Driver Name";
   public static jndiNamePropertyLabel = "JNDI Name";
   public static serviceCatalogSourceNameLabel = "Service Catalog Source";

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
@@ -286,7 +286,7 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
 
     const self = this;
     this.vdbService
-      .deployVdbForTables(this.tableSelector.getSelectedTables())
+      .deployVdbForConnection(this.tableSelector.getSelectedTables()[0].getConnection())
       .subscribe(
         (wasSuccess) => {
           // Deployment succeeded - wait for source vdb to become active

--- a/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.ts
+++ b/src/main/ngapp/src/app/dataservices/connection-table-selector/connection-table-selector.component.ts
@@ -121,9 +121,13 @@ export class ConnectionTableSelectorComponent implements OnInit {
     this.connectionLoadingState = LoadingState.LOADING;
     const self = this;
     this.connectionService
-      .getAllConnections()
+      .getConnections(true, false)
       .subscribe(
-        (conns) => {
+        (connectionSummaries) => {
+          const conns = [];
+          for ( const connectionSummary of connectionSummaries ) {
+            conns.push(connectionSummary.getConnection());
+          }
           self.allConnections = conns;
           self.filteredConnections = conns;
           self.connectionLoadingState = LoadingState.LOADED_VALID;

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.html
@@ -31,8 +31,8 @@
             data-placement="right"
             title="Inactive">
       </span>
-      <span class="pull-left fa fa-question-circle-o fa-2x card-action-icon"
-            style="color:orange;"
+      <span class="pull-left fa fa-times-circle-o fa-2x card-action-icon"
+            style="color:red;"
             *ngIf="dataservice.serviceDeploymentNotDeployed"
             data-toggle="tooltip"
             data-placement="right"

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.ts
@@ -36,7 +36,6 @@ export class DataserviceCardComponent implements DoCheck, OnInit {
   public static readonly editDataserviceEvent = "edit";
   public static readonly publishDataserviceEvent = "publish";
   public static readonly quickLookDataserviceEvent = "quickLook";
-  public static readonly refreshDataserviceEvent = "activate";
   public static readonly testDataserviceEvent = "test";
   public static readonly downloadDataserviceEvent = "download";
 
@@ -58,13 +57,11 @@ export class DataserviceCardComponent implements DoCheck, OnInit {
   private readonly activateActionId = "activate";
   private readonly activateActionIndex = 0; // index in moreActions
   private readonly deleteActionId = "delete";
-  private readonly deleteActionIndex = 3; // index in moreActions
+  private readonly deleteActionIndex = 2; // index in moreActions
   private readonly publishActionId = "publish";
-  private readonly publishActionIndex = 2; // index in moreActions
-  private readonly refreshActionId = "refresh";
-  private readonly refreshActionIndex = 1; // index in moreActions
+  private readonly publishActionIndex = 1; // index in moreActions
   private readonly downloadActionId = "download";
-  private readonly downloadActionIndex = 4; // index in moreActions
+  private readonly downloadActionIndex = 3; // index in moreActions
 
   private isLoading = true;
   private logger: LoggerService;
@@ -125,8 +122,6 @@ export class DataserviceCardComponent implements DoCheck, OnInit {
       this.onClick( DataserviceCardComponent.deleteDataserviceEvent );
     } else if ( action.id === this.publishActionId ) {
       this.onClick( DataserviceCardComponent.publishDataserviceEvent );
-    } else if ( action.id === this.refreshActionId ) {
-      this.onClick( DataserviceCardComponent.refreshDataserviceEvent );
     } else if ( action.id === this.downloadActionId ) {
       this.onClick( DataserviceCardComponent.downloadDataserviceEvent );
     } else {
@@ -148,7 +143,6 @@ export class DataserviceCardComponent implements DoCheck, OnInit {
       this.actionConfig.moreActions[ this.activateActionIndex ].disabled = this.isLoading;
       this.actionConfig.moreActions[ this.deleteActionIndex ].disabled = this.isLoading;
       this.actionConfig.moreActions[ this.publishActionIndex ].disabled = this.isLoading;
-      this.actionConfig.moreActions[ this.refreshActionIndex ].disabled = this.isLoading;
       this.actionConfig.moreActions[ this.downloadActionIndex ].disabled = this.isLoading;
     }
 
@@ -165,12 +159,6 @@ export class DataserviceCardComponent implements DoCheck, OnInit {
           id: this.activateActionId,
           title: "Activate",
           tooltip: "Activate"
-        },
-        {
-          disabled: true,
-          id: this.refreshActionId,
-          title: "Refresh",
-          tooltip: "Refresh"
         },
         {
           disabled: true,

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
@@ -68,7 +68,7 @@ export class DataservicesCardsComponent {
       case DataserviceCardComponent.quickLookDataserviceEvent:
         this.quickLookDataservice.emit( event.dataserviceName );
         break;
-      case DataserviceCardComponent.refreshDataserviceEvent:
+      case DataserviceCardComponent.activateDataserviceEvent:
         this.activateDataservice.emit( event.dataserviceName );
         break;
       case DataserviceCardComponent.testDataserviceEvent:

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
@@ -34,7 +34,6 @@
                 <span class="pull-left fa fa-spinner fa-pulse"
                       *ngIf="item.serviceDeploymentLoading">
                 </span>
-
                 <span class="pull-left fa fa-cogs fa-2x"
                       style="color:grey;"
                       *ngIf="item.serviceNotPublished"
@@ -48,7 +47,7 @@
                       data-toggle="tooltip"
                       data-placement="right"
                       title="Publishing Failed">
-               </span>
+                </span>
                 <span class="pull-left fa fa-cog fa-spin fa-2x"
                       style="color:orange;"
                       *ngIf="item.servicePublishing"
@@ -62,9 +61,7 @@
                       data-toggle="tooltip"
                       data-placement="left"
                       title="Published">
-      </span>
-
-
+                </span>
                 <a class="object-name-link" [routerLink]="[item.getId()]" (click)="onEditDataservice(item.getId())">{{ item.getId() }}</a>
                 <div class="list-pf-description">{{ getDescription( item ) }}</div>
               </div>
@@ -86,7 +83,6 @@
                                                           activateActionTemplate,
                                                           publishActionTemplate,
                                                           downloadActionTemplate,
-                                                          refreshActionTemplate,
                                                           deleteActionTemplate )"
                          (onActionSelect)="handleAction($event, item)">
               <ng-template #editActionTemplate let-action="action">
@@ -106,9 +102,6 @@
               </ng-template>
               <ng-template #downloadActionTemplate let-action="action">
                 <span class="fa fa-download">&nbsp;</span>{{ action.title }}
-              </ng-template>
-              <ng-template #refreshActionTemplate let-action="action">
-                <span class="fa fa-refresh">&nbsp;</span>{{ action.title }}
               </ng-template>
               <ng-template #deleteActionTemplate let-action="action">
                 <span class="fa fa-trash-o">&nbsp;</span>{{ action.title }}

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
@@ -42,7 +42,6 @@ export class DataservicesListComponent implements OnInit {
   private static readonly previewActionId = "preview";
   private static readonly publishActionId = "publish";
   private static readonly downloadActionId = "download";
-  private static readonly refreshActionId = "refresh";
   private static readonly testActionId = "test";
 
   public items: Dataservice[];
@@ -82,7 +81,6 @@ export class DataservicesListComponent implements OnInit {
    * @param activateActionTemplate {TemplateRef} the activate action template
    * @param publishActionTemplate {TemplateRef} the publish action template
    * @param downloadActionTemplate {TemplateRef} the download action template
-   * @param refreshActionTemplate {TemplateRef} the refresh action template
    * @param deleteActionTemplate {TemplateRef} the delete action template
    * @returns {ActionConfig} the actions configuration
    */
@@ -93,7 +91,6 @@ export class DataservicesListComponent implements OnInit {
                           activateActionTemplate: TemplateRef< any >,
                           publishActionTemplate: TemplateRef< any >,
                           downloadActionTemplate: TemplateRef< any >,
-                          refreshActionTemplate: TemplateRef< any >,
                           deleteActionTemplate: TemplateRef< any > ): ActionConfig {
     const actionConfig = {
       primaryActions: [
@@ -126,13 +123,6 @@ export class DataservicesListComponent implements OnInit {
           template: activateActionTemplate,
           title: "Activate",
           tooltip: "Activate this data service"
-        },
-        {
-          disabled: ds.serviceDeploymentLoading,
-          id: DataservicesListComponent.refreshActionId,
-          template: refreshActionTemplate,
-          title: "Refresh",
-          tooltip: "Refresh this data service"
         },
         {
           disabled: ds.serviceDeploymentLoading,

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.ts
@@ -242,9 +242,13 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
       );
 
     this.connectionService
-      .getAllConnections()
+      .getConnections(true, false)
       .subscribe(
-        ( connections ) => {
+        ( connectionSummaries ) => {
+          const connections = [];
+          for ( const connectionSummary of connectionSummaries ) {
+            connections.push(connectionSummary.getConnection());
+          }
           self.connectionsExist = connections.length !== 0;
           self.loaded( self.connectionsLoadedTag );
         },

--- a/src/main/ngapp/src/app/dataservices/shared/connection-summary.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/connection-summary.model.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Connection } from "@connections/shared/connection.model";
+import { NamedVdbStatus } from "@dataservices/shared/named-vdb-status.model";
+
+/**
+ * ConnectionSummary model.
+ */
+export class ConnectionSummary {
+
+  private connection: Connection;
+  private status: NamedVdbStatus;
+
+  /**
+   * @param {Object} json the JSON representation of a ConnectionSummary
+   * @returns {ConnectionSummary} the new ConnectionSummary (never null)
+   */
+  public static create( json: object = {} ): ConnectionSummary {
+    const connSummary = new ConnectionSummary();
+    for (const field of Object.keys(json)) {
+      if (field === "connection") {
+        // length of 2 or shorter - no object.  TODO: better way to do this?
+        if (JSON.stringify(json[field]).length > 2) {
+          connSummary.setConnection(Connection.create(json[field]));
+        }
+      } else if (field === "status") {
+        // length of 2 or shorter - no object.  TODO: better way to do this?
+        if (JSON.stringify(json[field]).length > 2) {
+          connSummary.setNamedVdbStatus(NamedVdbStatus.create(json[field]));
+        }
+      }
+    }
+    return connSummary;
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {Connection} the connection
+   */
+  public getConnection(): Connection {
+    return this.connection;
+  }
+
+  /**
+   * @returns {boolean} 'true' if namedVdbStatus exists
+   */
+  public hasNamedVdbStatus(): boolean {
+    return (this.status && this.status !== null);
+  }
+
+  /**
+   * @returns {NamedVdbStatus} the named vdbStatus
+   */
+  public getNamedVdbStatus(): NamedVdbStatus {
+    return this.status;
+  }
+
+  /**
+   * @param {Connection} connection the named connection
+   */
+  public setConnection( connection: Connection ): void {
+    this.connection = connection;
+  }
+
+  /**
+   * @param {NamedVdbStatus} status the named vdbStatus
+   */
+  public setNamedVdbStatus( status: NamedVdbStatus ): void {
+    this.status = status;
+  }
+
+  /**
+   * Set all object values using the supplied ConnectionSummary json
+   * @param {Object} values
+   */
+  public setValues(values: object = {}): void {
+    Object.assign(this, values);
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
@@ -68,8 +68,8 @@ export class DataserviceService extends ApiService {
     this.notifierService = notifierService;
     this.vdbService = vdbService;
     this.appSettingsService = appSettings;
-    // Polls to fire Dataservice state updates every minute
-    this.pollDataserviceStatus(60);
+    // Polls to fire Dataservice state updates every 15 sec
+    this.pollDataserviceStatus(15);
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
@@ -26,13 +26,13 @@ import { VdbModel } from "@dataservices/shared/vdb-model.model";
 import { VdbStatus } from "@dataservices/shared/vdb-status.model";
 import { Vdb } from "@dataservices/shared/vdb.model";
 import { VdbService } from "@dataservices/shared/vdb.service";
+import { Virtualization } from "@dataservices/shared/virtualization.model";
 import { TestDataService } from "@shared/test-data.service";
 import "rxjs/add/observable/of";
 import "rxjs/add/observable/throw";
 import "rxjs/add/operator/catch";
 import "rxjs/add/operator/map";
 import { Observable } from "rxjs/Observable";
-import { Virtualization } from "@dataservices/shared/virtualization.model";
 
 @Injectable()
 export class MockVdbService extends VdbService {

--- a/src/main/ngapp/src/app/dataservices/shared/named-vdb-status.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/named-vdb-status.model.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { VdbStatus } from "@dataservices/shared/vdb-status.model";
+
+/**
+ * NamedVdbStatus model.
+ */
+export class NamedVdbStatus {
+
+  private objectName: string;
+  private vdbStatus: VdbStatus;
+
+  /**
+   * @param {Object} json the JSON representation of a NamedVdbStatus
+   * @returns {NamedVdbStatus} the new NamedVdbStatus (never null)
+   */
+  public static create( json: object = {} ): NamedVdbStatus {
+    const namedStatus = new NamedVdbStatus();
+    for (const field of Object.keys(json)) {
+      if (field === "objectName") {
+        namedStatus.setName(json[field]);
+      } else if (field === "vdbStatus") {
+        // length of 2 or shorter - no object.  TODO: better way to do this?
+        if (JSON.stringify(json[field]).length > 2) {
+          namedStatus.setVdbStatus(VdbStatus.create(json[field]));
+        }
+      }
+    }
+    return namedStatus;
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the vdbStatus name
+   */
+  public getName(): string {
+    return this.objectName;
+  }
+
+  /**
+   * @returns {boolean} 'true' if vdbStatus exists
+   */
+  public hasVdbStatus(): boolean {
+    return (this.vdbStatus && this.vdbStatus !== null);
+  }
+
+  /**
+   * @returns {VdbStatus} the vdbStatus
+   */
+  public getVdbStatus(): VdbStatus {
+    return this.vdbStatus;
+  }
+
+  /**
+   * @param {string} name the object name
+   */
+  public setName( name: string ): void {
+    this.objectName = name;
+  }
+
+  /**
+   * @param {VdbStatus} status the object VdbStatus
+   */
+  public setVdbStatus( status: VdbStatus ): void {
+    this.vdbStatus = status;
+  }
+
+  /**
+   * Set all object values using the supplied ConnectionSummary json
+   * @param {Object} values
+   */
+  public setValues(values: object = {}): void {
+    Object.assign(this, values);
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/notifier.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/notifier.service.ts
@@ -16,6 +16,7 @@ export class NotifierService {
   private deploymentStatusSubject: Subject<VdbStatus> = new ReplaySubject<VdbStatus>(1);
   private dataserviceDeployStateSubject: Subject< Map<string, DeploymentState> > = new ReplaySubject< Map<string, DeploymentState> >(1);
   private dataserviceVirtualizationSubject: Subject< Map<string, Virtualization> > = new ReplaySubject< Map<string, Virtualization> >(1);
+  private connectionStateSubject: Subject< Map<string, DeploymentState> > = new ReplaySubject< Map<string, DeploymentState> >(1);
 
   constructor() {
     // Nothing to do
@@ -88,5 +89,28 @@ export class NotifierService {
    */
   public clearDataserviceVirtualizationMap(): void {
     this.dataserviceVirtualizationSubject.next(null);
+  }
+
+  /**
+   * Sends map of Connection VDB DeploymentState
+   * @param {Map<string, DeploymentState>} stateMap
+   */
+  public sendConnectionStateMap(stateMap: Map<string, DeploymentState>): void {
+    this.connectionStateSubject.next(stateMap);
+  }
+
+  /**
+   * Get the map of Connection VDB DeploymentState
+   * @returns {Observable<Map<string, DeploymentState>>}
+   */
+  public getConnectionStateMap(): Observable<Map<string, DeploymentState>> {
+    return this.connectionStateSubject.asObservable();
+  }
+
+  /**
+   * Clears the Connection VDB DeploymentState
+   */
+  public clearConnectionStateMap(): void {
+    this.connectionStateSubject.next(null);
   }
 }

--- a/src/main/ngapp/src/app/dataservices/shared/vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb.service.ts
@@ -23,7 +23,6 @@ import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { NameValue } from "@dataservices/shared/name-value.model";
 import { NotifierService } from "@dataservices/shared/notifier.service";
-import { Table } from "@dataservices/shared/table.model";
 import { VdbModelSource } from "@dataservices/shared/vdb-model-source.model";
 import { VdbModel } from "@dataservices/shared/vdb-model.model";
 import { VdbStatus } from "@dataservices/shared/vdb-status.model";
@@ -335,15 +334,11 @@ export class VdbService extends ApiService {
   }
 
   /**
-   * Create and deploy a VDB for the provided tables.  Currently we require all tables to
-   * be from the same connection source.
-   * @param {Table[]} tables
+   * Create and deploy a VDB for the provided connection.
+   * @param {Connection} connection
    * @returns {Observable<boolean>}
    */
-  public deployVdbForTables(tables: Table[]): Observable<boolean> {
-    // Currently requiring all tables from same connection
-    const connection: Connection = tables[0].getConnection();
-
+  public deployVdbForConnection(connection: Connection): Observable<boolean> {
     const vdbName = this.deriveVdbName(connection);
     const vdbModelName = this.deriveVdbModelName(connection);
     const vdbModelSourceName = this.deriveVdbModelSourceName(connection);

--- a/src/main/ngapp/src/app/shared/test-data.service.ts
+++ b/src/main/ngapp/src/app/shared/test-data.service.ts
@@ -19,13 +19,14 @@ import { Injectable } from "@angular/core";
 import { Connection } from "@connections/shared/connection.model";
 import { SchemaInfo } from "@connections/shared/schema-info.model";
 import { ServiceCatalogSource } from "@connections/shared/service-catalog-source.model";
+import { ConnectionSummary } from "@dataservices/shared/connection-summary.model";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
+import { NamedVdbStatus } from "@dataservices/shared/named-vdb-status.model";
+import { PublishState } from "@dataservices/shared/publish-state.enum";
 import { QueryResults } from "@dataservices/shared/query-results.model";
 import { VdbStatus } from "@dataservices/shared/vdb-status.model";
 import { Vdb } from "@dataservices/shared/vdb.model";
-import { VirtualAction } from "rxjs/scheduler/VirtualTimeScheduler";
 import { Virtualization } from "@dataservices/shared/virtualization.model";
-import { PublishState } from "@dataservices/shared/publish-state.enum";
 
 @Injectable()
 export class TestDataService {
@@ -82,6 +83,42 @@ export class TestDataService {
   // VDB Status
   // =================================================================
 
+  private static status1 = VdbStatus.create(
+    {
+      "name": TestDataService.accountsVdb.getName(),
+      "deployedName": TestDataService.accountsVdb.getName() + "-vdb.xml",
+      "version": TestDataService.accountsVdb.getVersion(),
+      "active": true,
+      "loading": false,
+      "failed": false,
+      "errors": []
+    }
+  );
+
+  private static status2 = VdbStatus.create(
+    {
+      "name": TestDataService.employeesVdb.getName(),
+      "deployedName": TestDataService.employeesVdb.getName() + "-vdb.xml",
+      "version": TestDataService.employeesVdb.getVersion(),
+      "active": true,
+      "loading": false,
+      "failed": false,
+      "errors": []
+    }
+  );
+
+  private static status3 = VdbStatus.create(
+    {
+      "name": TestDataService.productsVdb.getName(),
+      "deployedName": TestDataService.productsVdb.getName() + "-vdb.xml",
+      "version": TestDataService.productsVdb.getVersion(),
+      "active": true,
+      "loading": false,
+      "failed": false,
+      "errors": []
+    }
+  );
+
   private static vdbStatuses =
     {
       "keng__baseUri": "http://das-beetle-studio.192.168.42.142.nip.io/vdb-builder/v1/",
@@ -125,6 +162,30 @@ export class TestDataService {
         }
       ]
     };
+
+  // =================================================================
+  // NamedVdbStatus
+  // =================================================================
+
+  private static namedStatus1 = NamedVdbStatus.create(
+    {
+      "objectName": "AccountConn",
+      "vdbStatus": TestDataService.status1
+    },
+  );
+
+  private static namedStatus2 = NamedVdbStatus.create(
+    {
+      "objectName": "EmployeeConn",
+      "vdbStatus": TestDataService.status2
+    }
+  );
+
+  private static namedStatus3 = NamedVdbStatus.create(
+    {
+      "objectName": "ProductConn"
+    }
+  );
 
   // =================================================================
   // ServiceCatalog DataSources
@@ -301,6 +362,28 @@ export class TestDataService {
       ]
     }
   );
+
+  // =================================================================
+  // Connection Summaries
+  // =================================================================
+
+  private static connSummariesConnOnly = [
+    TestDataService.createConnectionSummary(TestDataService.conn1, null),
+    TestDataService.createConnectionSummary(TestDataService.conn2, null),
+    TestDataService.createConnectionSummary(TestDataService.conn3, null)
+  ];
+
+  private static connSummariesSchemaStatusOnly = [
+    TestDataService.createConnectionSummary(null, TestDataService.namedStatus1),
+    TestDataService.createConnectionSummary(null, TestDataService.namedStatus2),
+    TestDataService.createConnectionSummary(null, TestDataService.namedStatus3)
+  ];
+
+  private static connSummariesBothConnAndStatus = [
+    TestDataService.createConnectionSummary(TestDataService.conn1, TestDataService.namedStatus1),
+    TestDataService.createConnectionSummary(TestDataService.conn2, TestDataService.namedStatus2),
+    TestDataService.createConnectionSummary(TestDataService.conn3, TestDataService.namedStatus3)
+  ];
 
   // =================================================================
   // SchemaInfos for the connections
@@ -844,6 +927,19 @@ export class TestDataService {
     return catalogSource;
   }
 
+  /**
+   * Create a ConnectionSummary using the specified info
+   * @param {Connection} conn the connection
+   * @param {NamedVdbStatus} status the named vdb status
+   * @returns {ConnectionSummary}
+   */
+  private static createConnectionSummary( conn: Connection, status: NamedVdbStatus ): ConnectionSummary {
+    const connectionSummary = new ConnectionSummary();
+    connectionSummary.setConnection(conn);
+    connectionSummary.setNamedVdbStatus(status);
+    return connectionSummary;
+  }
+
   constructor() {
     this.vdbStatuses = TestDataService.vdbStatuses.vdbs.map(( vdbStatus ) => VdbStatus.create( vdbStatus ) );
     this.virtualizations = [
@@ -953,10 +1049,19 @@ export class TestDataService {
   }
 
   /**
+   * Get connection summaries based on supplied parameters
+   * @param {boolean} includeConnection include connection in the summary
+   * @param {boolean} includeSchemaStatus include schema status in the summary
    * @returns {Connection[]} the array of test connections
    */
-  public getConnections(): Connection[] {
-    return this.connections;
+  public getConnectionSummaries(includeConnection: boolean, includeSchemaStatus: boolean): ConnectionSummary[] {
+    if (includeConnection && includeSchemaStatus) {
+      return TestDataService.connSummariesBothConnAndStatus;
+    } else if (includeConnection && !includeSchemaStatus) {
+      return TestDataService.connSummariesConnOnly;
+    } else if (includeSchemaStatus && !includeConnection) {
+      return TestDataService.connSummariesSchemaStatusOnly;
+    }
   }
 
   /**

--- a/src/main/ngapp/src/environments/environment.ts
+++ b/src/main/ngapp/src/environments/environment.ts
@@ -59,6 +59,6 @@ export const environment = {
   komodoServiceUrl: komodoUrlPrefix + komodoEngine + "/" + komodoRestVersion + "/service",
 
   // Indicates if in UI development mode where OpenShift will not be used.
-  uiDevMode: true
+  uiDevMode: false
 
 };


### PR DESCRIPTION
This PR incorporates the first part of TTOOLS-371 - utilization of teiid schema for connections.  A companion PR in teiid-komodo must be merged with this PR.
- Adds a status indicator to the connection cards and list rows, similar to the Dataservice statuses.  For a connection, the status indicates whether the connection schema is active.
- Adds an 'activate' action so that the user can initiate redeploy of the connection
- removes 'refresh' action as it was redundant
- removes 'ping' action since the connection status now reflects the connection state
- adapts the rest calls to the new teiid-komodo services and creates models for the service returns.
- adds connection updating to notificationService, so that the connection summary page can poll for connection status updates.
- updates unitTests and fixes other minor issues