### PR TITLE
TEIIDTOOLS-405 Fixes vdb polling issue

### DIFF
--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
@@ -281,17 +281,17 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
     // Sets page in progress status
     this.setFinalPageInProgress();
 
-    const sourceVdbName = this.tableSelector.getSelectedTables()[0].getConnection().getId() + VdbsConstants.SOURCE_VDB_SUFFIX;
-    this.sourceVdbUnderDeployment = sourceVdbName;
+    const conn = this.tableSelector.getSelectedTables()[0].getConnection();
+    this.sourceVdbUnderDeployment = this.vdbService.deriveSourceVdbName(conn);
 
     const self = this;
     this.vdbService
-      .deployVdbForConnection(this.tableSelector.getSelectedTables()[0].getConnection())
+      .deployVdbForConnection(conn)
       .subscribe(
         (wasSuccess) => {
           // Deployment succeeded - wait for source vdb to become active
           if (wasSuccess) {
-            self.vdbService.pollForActiveVdb(sourceVdbName, 240, 5);
+            self.vdbService.pollForActiveVdb(self.sourceVdbUnderDeployment, 240, 5);
           } else {
             self.setFinalPageComplete(false);
             self.sourceVdbUnderDeployment = null;

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
@@ -338,7 +338,7 @@ export class DataserviceService extends ApiService {
   public createDataserviceForSingleSourceTables(dataservice: NewDataservice, sourceTables: Table[]): Observable<boolean> {
     // All tables from same connection
     const connection: Connection = sourceTables[0].getConnection();
-    const sourceVdbName = this.vdbService.deriveVdbName(connection);
+    const sourceVdbName = this.vdbService.deriveSourceVdbName(connection);
     const sourceModelName = this.vdbService.deriveVdbModelName(connection);
     const sourceModelSourceName = this.vdbService.deriveVdbModelSourceName(connection);
     const vdbPath = this.getKomodoUserWorkspacePath() + "/" + sourceVdbName;

--- a/src/main/ngapp/src/app/dataservices/shared/vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdb.service.ts
@@ -113,12 +113,12 @@ export class VdbService extends ApiService {
   }
 
   /**
-   * Derive the vdb name from the given connection
+   * Derive the source vdb name from the given connection
    *
    * @param {Connection} connection
    * @returns {string}
    */
-  public deriveVdbName(connection: Connection): string {
+  public deriveSourceVdbName(connection: Connection): string {
     const name = connection.getId() + VdbsConstants.SOURCE_VDB_SUFFIX;
     return name.toLowerCase();
   }
@@ -339,7 +339,7 @@ export class VdbService extends ApiService {
    * @returns {Observable<boolean>}
    */
   public deployVdbForConnection(connection: Connection): Observable<boolean> {
-    const vdbName = this.deriveVdbName(connection);
+    const vdbName = this.deriveSourceVdbName(connection);
     const vdbModelName = this.deriveVdbModelName(connection);
     const vdbModelSourceName = this.deriveVdbModelSourceName(connection);
 


### PR DESCRIPTION
The create dataservice wizard was not completing in beetle studio, due to a vdb status polling issue.  There were some changes made in a previous commit to lowercase all of the VDB names, which broke the polling function.
- renamed 'deriveVdbName' to 'deriveSourceVdbName' in VdbService, to better denote that the source vdb is the target.
- changed add-dataservice-wizard to utilize the deriveSourceVdbName function