### PR TITLE
TEIIDTOOLS-391 Improve service catalog source selection

### DIFF
--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.html
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.html
@@ -77,8 +77,7 @@
             <label class="col-sm-2 control-label">ServiceCatalog Source</label>
             <div class="col-sm-5" *ngIf="hasServiceCatalogSources">
               <select (change)="selectedServiceCatalogSourceChanged($event.target.value)">
-                <option disabled
-                        [ngValue]="emptyServiceCatalogSource">{{ emptyServiceCatalogSource.getId() }}</option>
+                <option [ngValue]="emptyServiceCatalogSource">{{ emptyServiceCatalogSource.getId() }}</option>
                 <option *ngFor="let catalogSource of serviceCatalogSources"
                         [ngValue]="catalogSource"
                         [selected]="catalogSource.getId() == selectedServiceCatalogSource.getId()">{{ catalogSource.getId() }}</option>

--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
@@ -197,6 +197,9 @@ export class AddConnectionWizardComponent implements OnInit {
    */
   public selectedServiceCatalogSourceChanged( newValue ): void {
     this.selectedServiceCatalogSource = this.serviceCatSources.find((src) => src.getId() === newValue);
+    if (!this.selectedServiceCatalogSource || this.selectedServiceCatalogSource === null) {
+      this.selectedServiceCatalogSource = this.emptyServiceCatalogSource;
+    }
     this.updatePage2ValidStatus();
   }
 
@@ -455,6 +458,11 @@ export class AddConnectionWizardComponent implements OnInit {
             if ( source.getType() === connType.getName() ) {
               self.serviceCatSources.push(source);
             }
+          }
+
+          // Create mode - if only one service catalog source available, pre-select it
+          if (!self.wizardService.isEdit() && self.serviceCatSources.length === 1) {
+            self.selectedServiceCatalogSource = self.serviceCatSources[0];
           }
 
           // Edit mode select the service catalog source


### PR DESCRIPTION
If only one service catalog source is available in the AddConnectionWizard, it is now auto-selected when the user goes to page2 of the wizard.
- removed 'disabled' from the html option, so that the component can select it.
- adds code in component to auto-select catalog if it is the only option.
