### PR TITLE
TTOOLS-410 Resolve issue with duplicate empty states

### DIFF
--- a/src/main/ngapp/src/app/connections/connections.component.html
+++ b/src/main/ngapp/src/app/connections/connections.component.html
@@ -63,7 +63,7 @@
 
       <!-- The list or card view -->
       <div class="col-md-12" *ngIf="isLoaded('connections')">
-        <app-connections-list *ngIf="isListLayout"
+        <app-connections-list *ngIf="isListLayout && hasConnections"
                               [connections]="filteredConnections"
                               [selectedConnections]="selectedConnections"
                               (activateConnection)="onActivate($event)"
@@ -71,7 +71,7 @@
                               (deleteConnection)="onDelete($event)"
                               (connectionSelected)="onSelected($event)"
                               (connectionDeselected)="onDeselected($event)"></app-connections-list>
-        <app-connections-cards *ngIf="isCardLayout"
+        <app-connections-cards *ngIf="isCardLayout && hasConnections"
                                [connections]="filteredConnections"
                                [selectedConnections]="selectedConnections"
                                (activateConnection)="onActivate($event)"

--- a/src/main/ngapp/src/app/connections/connections.component.ts
+++ b/src/main/ngapp/src/app/connections/connections.component.ts
@@ -193,6 +193,13 @@ export class ConnectionsComponent extends AbstractPageComponent implements OnIni
   }
 
   /**
+   * @returns {boolean} 'true' if any connections are available
+   */
+  public get hasConnections(): boolean {
+    return this.allConns.length > 0;
+  }
+
+  /**
    * @returns {Connection[]} the array of filtered connections
    */
   public get filteredConnections(): Connection[] {

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -82,13 +82,13 @@
         </div>
 
         <div class="{{cardListAreaCss}}">
-          <app-dataservices-list *ngIf="isListLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
+          <app-dataservices-list *ngIf="isListLayout && hasDataservices" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
                                  (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
                                  (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
                                  (editDataservice)="onEdit($event)" (quickLookDataservice)="onQuickLook($event)"
                                  (downloadDataservice)="onDownload($event)" (dataserviceSelected)="onSelected($event)"
                                  (dataserviceDeselected)="onDeselected($event)"></app-dataservices-list>
-          <app-dataservices-cards *ngIf="isCardLayout" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
+          <app-dataservices-cards *ngIf="isCardLayout && hasDataservices" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
                                   (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
                                   (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
                                   (editDataservice)="onEdit($event)" (quickLookDataservice)="onQuickLook($event)"

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.ts
@@ -324,6 +324,13 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
   }
 
   /**
+   * @returns {boolean} 'true' if any dataservices are available
+   */
+  public get hasDataservices(): boolean {
+    return this.allServices.length > 0;
+  }
+
+  /**
    * @returns {Dataservice[]} the array of filtered dataservices
    */
   public get filteredDataservices(): Dataservice[] {


### PR DESCRIPTION
Resolves issue where there were two "emptyState" on the list views (when no items were available to show).

Problem is that the pfng-list has a built in empty state which gets displayed.  So that was showing in addition to our custom empty state.

I resolved the issue by completely hiding the list and card views when there are no items to show.  added 'hasConnections' and 'hasDataservices' accessors to the components.  Then used the accessors in the html to only show the list and card views when true.