### PR TITLE
TEIIDTOOLS-411 Change terminology in UI to Data Virtualization

### DIFF
--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.html
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.html
@@ -67,16 +67,16 @@
           <div [ngClass]="'form-group'">
             <label class="col-sm-2 control-label">Description</label>
             <div class="col-sm-5" *ngIf="hasServiceCatalogSources">
-              <textarea class="form-control" rows="2" maxlength="256" formControlName="description"></textarea>
+              <textarea class="form-control" rows="2" maxlength="256" formControlName="description" title="" ></textarea>
             </div>
             <div class="col-sm-5" *ngIf="!hasServiceCatalogSources">
-              <textarea class="form-control" rows="2" maxlength="256" formControlName="description" disabled="true"></textarea>
+              <textarea class="form-control" rows="2" maxlength="256" formControlName="description" title="" disabled="true"></textarea>
             </div>
           </div>
           <div [ngClass]="hasSelectedServiceCatalogSource ? 'form-group' : 'form-group has-error'">
             <label class="col-sm-2 control-label">ServiceCatalog Source</label>
             <div class="col-sm-5" *ngIf="hasServiceCatalogSources">
-              <select (change)="selectedServiceCatalogSourceChanged($event.target.value)">
+              <select (change)="selectedServiceCatalogSourceChanged($event.target.value)" title="" >
                 <option [ngValue]="emptyServiceCatalogSource">{{ emptyServiceCatalogSource.getId() }}</option>
                 <option *ngFor="let catalogSource of serviceCatalogSources"
                         [ngValue]="catalogSource"

--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.ts
@@ -619,7 +619,7 @@ export class AddConnectionWizardComponent implements OnInit {
     }
     // Error visible if message has content
     if (this.errorDetailMessage.length === 0) {
-      this.errorDetailMessage = "Please check dataservice entries and retry";
+      this.errorDetailMessage = "Please check data virtualization entries and retry";
     }
   }
 }

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.html
@@ -43,7 +43,7 @@
         <div [ngClass]="'form-group'">
           <label class="col-sm-2 control-label">Description</label>
           <div class="col-sm-7">
-            <textarea class="form-control" rows="2" maxlength="256" formControlName="description"></textarea>
+            <textarea class="form-control" rows="2" maxlength="256" formControlName="description" title=""></textarea>
           </div>
         </div>
         <div [ngClass]="hasSelectedConnection() ? 'form-group' : 'form-group has-error'">
@@ -54,7 +54,7 @@
             Connection
           </label>
           <div class="col-sm-7">
-            <select ([ngModel])="selectedConnection" (change)="selectedConnectionChanged($event)">
+            <select ([ngModel])="selectedConnection" (change)="selectedConnectionChanged($event)" title="">
               <option disabled selected value [ngValue]="emptyConnection">{{ emptyConnection.getId() }}</option>
               <option *ngFor="let connection of sourceTableConnections" [ngValue]="connection">
                 {{ connection.getId() }}
@@ -88,7 +88,7 @@
           <div class="wizard-pf-success-icon"><span class="glyphicon glyphicon-ok-circle"></span></div>
           <h3 class="blank-slate-pf-main-action">{{ finalPageTitle }}</h3>
           <p class="blank-slate-pf-secondary-action">{{ finalPageMessage }}</p>
-          <button class="btn btn-lg btn-primary" type="button" (click)="onDeployDataservice()">View All Dataservices</button>
+          <button class="btn btn-lg btn-primary" type="button" (click)="onDeployDataservice()">View All Data Virtualizations</button>
         </div>
         <!-- Create Failed -->
         <div class="wizard-pf-complete blank-slate-pf" *ngIf="createComplete && !createSuccessful">

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
@@ -136,7 +136,7 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
     // Wizard Configuration
     this.wizardConfig = {
       embedInPage: true,
-      loadingTitle: "Dataservice Wizard loading",
+      loadingTitle: "Data Virtualization Wizard loading",
       loadingSecondaryInfo: "Please wait for the wizard to finish loading...",
       contentHeight: "500px",
       done: false
@@ -218,7 +218,7 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
    */
   public get step1InstructionMessage(): string {
     if (!this.tableSelector.valid) {
-      return "Please select tables for the Dataservice";
+      return "Please select tables for the Data virtualization";
     } else {
       return "Select tables, then click Next to continue";
     }
@@ -229,9 +229,9 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
    */
   public get step2InstructionMessage(): string {
     if (this.wizardService.isEdit()) {
-      return "Review selections.  Click Update to update the Dataservice";
+      return "Review selections.  Click Update to update the Virtualization";
     }
-    return "Enter a name, select a connection, and review the table selections. Click Create to create the Dataservice";
+    return "Enter a name, select a connection, and review the table selections. Click Create to create the Virtualization";
   }
 
   /*
@@ -502,10 +502,10 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
     this.createSuccessful = false;
     if (this.wizardService.isEdit()) {
       this.theFinalPageTitle = "Update in progress";
-      this.theFinalPageMessage = "The dataservice is being updated.";
+      this.theFinalPageMessage = "The virtualization is being updated.";
     } else {
       this.theFinalPageTitle = "Creation in progress";
-      this.theFinalPageMessage = "The dataservice is being created.";
+      this.theFinalPageMessage = "The virtualization is being created.";
     }
     this.step2bConfig.nextEnabled = false;
     this.step2bConfig.previousEnabled = false;
@@ -523,18 +523,18 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
     if (wasSuccessful) {
       if (this.wizardService.isEdit()) {
         this.theFinalPageTitle = "Update was successful";
-        this.theFinalPageMessage = "The dataservice was updated successfully. Click on the button to see all dataservices.";
+        this.theFinalPageMessage = "The data virtualization was updated successfully. Click on the button to see all virtualizations.";
       } else {
         this.theFinalPageTitle = "Creation was successful";
-        this.theFinalPageMessage = "The dataservice was created successfully. Click on the button to see all dataservices.";
+        this.theFinalPageMessage = "The data virtualization was created successfully. Click on the button to see all virtualizations.";
       }
     } else {
       if (this.wizardService.isEdit()) {
         this.theFinalPageTitle = "Update failed";
-        this.theFinalPageMessage = "The dataservice update failed!";
+        this.theFinalPageMessage = "The data virtualization update failed!";
       } else {
         this.theFinalPageTitle = "Creation failed";
-        this.theFinalPageMessage = "The dataservice creation failed!";
+        this.theFinalPageMessage = "The data virtualization creation failed!";
       }
     }
   }
@@ -555,7 +555,7 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
     }
     // Error visible if message has content
     if (this.errorDetailMessage.length === 0) {
-      this.errorDetailMessage = "Please check dataservice entries and retry";
+      this.errorDetailMessage = "Please check data virtualization entries and retry";
     }
   }
 

--- a/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.html
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice/add-dataservice.component.html
@@ -1,13 +1,13 @@
 <div class="app-feature-content">
   <div id="dataservices-breadcrumb-bar">
     <app-breadcrumbs>
-      <li i18n="@@dataservicesCards.dataservices" app-breadcrumb label="Dataservices" icon="table" [route]="[ dataservicesLink ]"></li>
-      <li i18n="@@dataservicesCards.addDataservice" app-breadcrumb label="Add Dataservice" icon="plus" class="active"></li>
+      <li i18n="@@dataservicesCards.dataservices" app-breadcrumb label="Data Virtualizations" icon="table" [route]="[ dataservicesLink ]"></li>
+      <li i18n="@@dataservicesCards.addDataservice" app-breadcrumb label="Add Data Virtualization" icon="plus" class="active"></li>
     </app-breadcrumbs>
   </div>
   <div class="container-fluid" *ngIf="!pageError">
     <div class="col-sm-12">
-      <h2 class="app-feature-title" i18n="@@add-dataservice.addDataservice">Add Dataservice</h2>
+      <h2 class="app-feature-title" i18n="@@add-dataservice.addDataservice">Add Data Virtualization</h2>
     </div>
     <!-- Add Dataservice Wizard -->
     <div class="row">

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -2,7 +2,7 @@
 
   <div id="dataservices-breadcrumb-bar">
     <app-breadcrumbs>
-      <li i18n="@@dataservices.dataservices" app-breadcrumb label="Dataservices" icon="table" class="active"></li>
+      <li i18n="@@dataservices.dataservices" app-breadcrumb label="Data Virtualizations" icon="table" class="active"></li>
     </app-breadcrumbs>
   </div>
 
@@ -10,7 +10,7 @@
 
   <div class="container-fluid dataservice-list-dataservices" *ngIf="!pageError">
     <div class="col-sm-12">
-      <h2 class="app-feature-title" i18n="@@dataservices.dataservices">Dataservices</h2>
+      <h2 class="app-feature-title" i18n="@@dataservices.dataservices">Data Virtualizations</h2>
     </div>
     <div class="row toolbar-pf">
       <div class="col-sm-12">
@@ -23,7 +23,7 @@
               <pfng-sort [config]="sortConfig" (onChange)="sortChange($event)"></pfng-sort>
           </div>
           <div class="form-group">
-            <a i18n="@@dataservices.addDataservice" class="btn btn-primary" (click)="onNew()">Add Dataservice</a>
+            <a i18n="@@dataservices.addDataservice" class="btn btn-primary" (click)="onNew()">Add Data Virtualization</a>
           </div>
           <div class="form-group toolbar-pf-view-selector">
             <ul class="list-inline">
@@ -61,7 +61,7 @@
             <div class="card-pf card-pf-accented">
               <div class="card-pf-heading">
                 <h1 class="card-pf-title">
-                  <span i18n="@@dataservices.loadingDataservices" class="spinner spinner-xs spinner-inline"></span> Loading Dataservices...
+                  <span i18n="@@dataservices.loadingDataservices" class="spinner spinner-xs spinner-inline"></span> Loading Data Virtualizations...
                 </h1>
               </div>
             </div>
@@ -101,7 +101,7 @@
         <div>
           <span class="pull-left fa fa-list-alt dataservice-results-action-icon" (click)="onTest(quickLookServiceName)"></span>
           <span class="pull-left fa fa-refresh dataservice-results-action-icon-refresh" (click)="onSubmitQuickLookQuery()"></span>
-          <span class="quicklook-title">Quick Look Results for Dataservice '{{ quickLookServiceName }}'</span>
+          <span class="quicklook-title">Quick Look Results for Data Virtualization '{{ quickLookServiceName }}'</span>
           <span class="pull-right fa fa-fw fa-close dataservice-results-action-icon-close" (click)="setQuickLookPanelOpenState(false)"></span>
         </div>
         <br>
@@ -114,5 +114,5 @@
 
 </div>
 <app-confirm-delete (deleteSelected)="onDeleteDataservice()">
-  <p i18n="@@dataservices.doYouReallyWantToDeleteSelectedDataservice" >Do you really want to delete the selected Dataservice?</p>
+  <p i18n="@@dataservices.doYouReallyWantToDeleteSelectedDataservice" >Do you really want to delete the selected Virtualization?</p>
 </app-confirm-delete>

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.spec.ts
@@ -62,12 +62,12 @@ describe("DataservicesComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should have Dataservices Title", () => {
-    console.log("========== [DataservicesComponent] should have Dataservices Title");
+  it("should have Data Virtualizations Title", () => {
+    console.log("========== [DataservicesComponent] should have Data Virtualizations Title");
     // query for the title <h2> by CSS element selector
     const de = fixture.debugElement.query(By.css("h2"));
     const el = de.nativeElement;
-    expect(el.textContent).toEqual("Dataservices");
+    expect(el.textContent).toEqual("Data Virtualizations");
   });
 
   it("should have Toolbar", () => {

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.ts
@@ -178,9 +178,9 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
       this.noConnectionsConfig = {
         actions: actionConfig,
         iconStyleClass: "pficon-warning-triangle-o",
-        info: "No dataservices were found. In order to create a dataservice, you must first create a connection. "
+        info: "No Data virtualizations were found. In order to create a virtualization, you must first create a connection. "
               + "Please click below to create a connection.",
-        title: "No Dataservices Available"
+        title: "No Data Virtualizations Available"
       } as EmptyStateConfig;
     }
 
@@ -193,8 +193,8 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
         primaryActions: [
           {
             id: "createDataserviceActionId",
-            title: "Add Dataservice",
-            tooltip: "Add a dataservice"
+            title: "Add Data Virtualization",
+            tooltip: "Add a data virtualization"
           }
         ]
       } as ActionConfig;
@@ -202,8 +202,8 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
       this.noDataservicesConfig = {
         actions: actionConfig,
         iconStyleClass: "pficon-warning-triangle-o",
-        info: "No dataservices were found. Please click below to create a dataservice.",
-        title: "No Dataservices Available"
+        info: "No Data virtualizations were found. Please click below to create a virtualization.",
+        title: "No Data Virtualizations Available"
       } as EmptyStateConfig;
     }
 

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
@@ -45,7 +45,7 @@ import { Subscription } from "rxjs/Subscription";
 export class DataserviceService extends ApiService {
 
   private static readonly nameValidationUrl = environment.komodoWorkspaceUrl
-                                              + DataservicesConstants.dataservicesRootPath
+                                              + DataservicesConstants.dataservicesRestPath
                                               + "/nameValidation/";
 
   // Observable dataservice state changes
@@ -163,7 +163,7 @@ export class DataserviceService extends ApiService {
    */
   public isValidName( name: string ): Observable< string > {
     if ( !name || name.length === 0 ) {
-      return Observable.of( "Dataservice name cannot be empty" );
+      return Observable.of( "Data virtualization name cannot be empty" );
     }
 
     const url = DataserviceService.nameValidationUrl + encodeURIComponent( name );
@@ -186,7 +186,7 @@ export class DataserviceService extends ApiService {
    */
   public getAllDataservices(): Observable<Dataservice[]> {
     return this.http
-      .get(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRootPath, this.getAuthRequestOptions())
+      .get(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRestPath, this.getAuthRequestOptions())
       .map((response) => {
         const dataservices = response.json();
         return dataservices.map((dataservice) => Dataservice.create( dataservice ));
@@ -201,7 +201,7 @@ export class DataserviceService extends ApiService {
    */
   public createDataservice(dataservice: NewDataservice): Observable<boolean> {
     return this.http
-      .post(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRootPath + "/" + dataservice.getId(),
+      .post(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRestPath + "/" + dataservice.getId(),
         dataservice, this.getAuthRequestOptions())
       .map((response) => {
         return response.ok;
@@ -217,7 +217,7 @@ export class DataserviceService extends ApiService {
   public deployDataservice(dataserviceName: string): Observable<boolean> {
     const servicePath = this.getKomodoUserWorkspacePath() + "/" + dataserviceName;
     return this.http
-      .post(environment.komodoTeiidUrl + DataservicesConstants.dataserviceRootPath,
+      .post(environment.komodoTeiidUrl + DataservicesConstants.dataserviceRestPath,
         { path: servicePath}, this.getAuthRequestOptions())
       .map((response) => {
         return response.ok;
@@ -234,7 +234,7 @@ export class DataserviceService extends ApiService {
    */
   public setServiceVdbForSingleSourceTables(dataserviceName: string, tablePaths: string[], modelSourcePath: string): Observable<boolean> {
     return this.http
-      .post(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRootPath + "/ServiceVdbForSingleSourceTables",
+      .post(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRestPath + "/ServiceVdbForSingleSourceTables",
         { dataserviceName, tablePaths, modelSourcePath}, this.getAuthRequestOptions())
       .map((response) => {
         return response.ok;
@@ -311,7 +311,7 @@ export class DataserviceService extends ApiService {
    */
   public deleteDataservice(dataserviceId: string): Observable<boolean> {
     return this.http
-      .delete(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRootPath + "/" + dataserviceId,
+      .delete(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRestPath + "/" + dataserviceId,
                this.getAuthRequestOptions())
       .map((response) => {
         return response.ok;

--- a/src/main/ngapp/src/app/dataservices/shared/dataservices-constants.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservices-constants.ts
@@ -17,23 +17,23 @@ export class DataservicesConstants {
   public static readonly dataservicesExport = "export";
   public static readonly dataservicesPublish = "publish";
 
-  public static readonly dataserviceRootRoute = "dataservice";
-  public static readonly dataserviceRootPath = "/" + DataservicesConstants.dataserviceRootRoute;
-
-  public static readonly dataservicesRootRoute = "dataservices";
+  public static readonly dataservicesRootRoute = "virtualizations";
   public static readonly dataservicesRootPath = "/" + DataservicesConstants.dataservicesRootRoute;
 
-  public static readonly addDataserviceRoute = DataservicesConstants.dataservicesRootRoute + "/add-dataservice";
-  public static readonly addDataservicePath = DataservicesConstants.dataservicesRootPath + "/add-dataservice";
+  public static readonly dataserviceRestPath = "/dataservice";
+  public static readonly dataservicesRestPath = "/dataservices";
 
-  public static readonly testDataserviceRoute = DataservicesConstants.dataservicesRootRoute + "/test-dataservice";
-  public static readonly testDataservicePath = DataservicesConstants.dataservicesRootPath + "/test-dataservice";
+  public static readonly addDataserviceRoute = DataservicesConstants.dataservicesRootRoute + "/add-virtualization";
+  public static readonly addDataservicePath = DataservicesConstants.dataservicesRootPath + "/add-virtualization";
+
+  public static readonly testDataserviceRoute = DataservicesConstants.dataservicesRootRoute + "/test-virtualization";
+  public static readonly testDataservicePath = DataservicesConstants.dataservicesRootPath + "/test-virtualization";
 
   public static dataserviceNameLabel = "Name";
   public static descriptionLabel = "Description";
 
   public static readonly dataservicesNavItem: NavigationItemConfig = {
-    title: "Data Services",
+    title: "Virtualizations",
     iconStyleClass: "fa fa-fw fa-table",
     url: DataservicesConstants.dataservicesRootPath
   };

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -125,13 +125,13 @@ export class MockDataserviceService extends DataserviceService {
 
   public isValidName( name: string ): Observable<string> {
     if ( !name || name.length === 0 ) {
-      return Observable.of( "Dataservice name cannot be empty" );
+      return Observable.of( "Data virtualization name cannot be empty" );
     }
 
     // make sure no dataservice exists with that name
     for ( const ds of this.services ) {
       if ( ds.getId() === name ) {
-        return Observable.of( "Dataservice with that name already exists" );
+        return Observable.of( "Data virtualization with that name already exists" );
       }
     }
 

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.html
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.html
@@ -1,26 +1,26 @@
 <div class="app-feature-content">
   <div id="dataservices-breadcrumb-bar">
     <app-breadcrumbs>
-      <li i18n="@@testDataservice.dataservices" app-breadcrumb label="Dataservices" icon="table" [route]="[ dataservicesLink ]"></li>
-      <li i18n="@@testDataservice.testDataservice" app-breadcrumb label="Test Dataservice" icon="play" class="active"></li>
+      <li i18n="@@testDataservice.dataservices" app-breadcrumb label="Data Virtualizations" icon="table" [route]="[ dataservicesLink ]"></li>
+      <li i18n="@@testDataservice.testDataservice" app-breadcrumb label="Test Data Virtualization" icon="play" class="active"></li>
     </app-breadcrumbs>
   </div>
   <div class="container-fluid" *ngIf="!pageError">
     <div class="col-sm-12">
-      <h2>Test Dataservice &apos;<strong>{{ this.dataservice.getId() }}</strong>&apos;</h2>
+      <h2>Test Data Virtualization &apos;<strong>{{ this.dataservice.getId() }}</strong>&apos;</h2>
     </div>
     <!-- Test Dataservice Controls -->
     <div class="col-sm-10" *ngIf="pageLoading">
       <div class="alert alert-info">
         <span class="pficon pficon-info"></span>
         <span class="spinner spinner-sm spinner-inline"></span>
-        <strong>Deploying the Dataservice...</strong>
+        <strong>Deploying the Data Virtualization...</strong>
       </div>
     </div>
     <div class="col-sm-10" *ngIf="pageLoadedInvalid">
       <div class="alert alert-info">
         <span class="pficon pficon-info"></span>
-        <strong>There was an error deploying the Dataservice!</strong>
+        <strong>There was an error deploying the Data Virtualization!</strong>
       </div>
     </div>
     <div class="col-sm-10" *ngIf="pageLoadedValid">


### PR DESCRIPTION
Purpose of this request is to change 'Data Service' in the display to 'Data Virtualization'.  Since the term data service has many overloaded meanings, was decided that data virtualization was a better fit.
- most of the changes are just textual changes in the html and components.  None of the underlying component names were changed (we may want to do that at some point).
- DataservicesConstants: Added 2 new constants 'dataserviceRestPath' and 'dataservicesRestPath'.  These are used in the DataservicesService where the rest urls are built.  This allowed changing the existing constants to 'virtualizations' for navigation, and using the new constants for the teiid-komodo rest calls.  Now the displayed browser urls match the UI terminology.
- few minor changes were made to address lint errors