### PR TITLE
TEIIDTOOLS-312 Adds support for Mongo

### DIFF
--- a/src/main/ngapp/src/app/connections/shared/connection.service.ts
+++ b/src/main/ngapp/src/app/connections/shared/connection.service.ts
@@ -183,16 +183,16 @@ export class ConnectionService extends ApiService {
     const connType2: ConnectionType = new ConnectionType();
     connType2.setName(ConnectionsConstants.connectionType_mysql);
     connType2.setDescription(ConnectionsConstants.connectionTypeDescription_mysql);
-    // const connType3: ConnectionType = new ConnectionType();
-    // connType3.setName(ConnectionsConstants.connectionType_mongodb);
-    // connType3.setDescription(ConnectionsConstants.connectionTypeDescription_mongodb);
+    const connType3: ConnectionType = new ConnectionType();
+    connType3.setName(ConnectionsConstants.connectionType_mongodb);
+    connType3.setDescription(ConnectionsConstants.connectionTypeDescription_mongodb);
     // const connType4: ConnectionType = new ConnectionType();
     // connType4.setName(ConnectionsConstants.connectionType_mariadb);
     // connType4.setDescription(ConnectionsConstants.connectionTypeDescription_mariadb);
 
     connectionTypes.push(connType1);
     connectionTypes.push(connType2);
-    // connectionTypes.push(connType3);
+    connectionTypes.push(connType3);
     // connectionTypes.push(connType4);
 
     return connectionTypes;

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.ts
@@ -432,6 +432,8 @@ export class AddDataserviceWizardComponent implements OnInit, OnDestroy {
     // Dataservice basic properties from step 1
     const dataservice: NewDataservice = this.dataserviceService.newDataserviceInstance(this.dataserviceName, this.dataserviceDescription);
 
+    // designate with wizard service that this dataservice is newly created.
+    this.wizardService.setNewlyAddedDataservice(this.dataserviceName);
     const self = this;
     this.dataserviceService
       .createDataserviceForSingleSourceTables(dataservice, this.tableSelector.getSelectedTables())

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.ts
@@ -64,7 +64,6 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
   public readonly exportFailedHeader: string = "Publishing Failed:  ";
   public readonly connectionsLoadedTag = "connections";
 
-  public readonly downloadInProgressHeader: string = "Downloading:  ";
   public readonly downloadSuccessHeader: string = "Download Succeeded:  ";
   public readonly downloadFailedHeader: string = "Download Failed:  ";
 
@@ -702,6 +701,10 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
       // For displayed dataservices, update the Deployment State using supplied services
       for ( const dService of this.filteredDataservices ) {
         const serviceId = dService.getId();
+        // For newly added services, leave state alone until wait expires
+        if (serviceId === this.wizardService.getNewlyAddedDataservice()) {
+          continue;
+        }
         if (stateMap && stateMap.has(serviceId)) {
           dService.setServiceDeploymentState(stateMap.get(serviceId));
         }

--- a/src/main/ngapp/src/app/dataservices/shared/wizard.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/wizard.service.ts
@@ -6,12 +6,16 @@ import { Dataservice } from "@dataservices/shared/dataservice.model";
 @Injectable()
 export class WizardService {
 
+  private static newlyAddedServiceWaitMillis = 5000;  // Wait of 5 sec
+
   private selectedConnectionTables: ConnectionTable[] = [];
   private edit = false;
   private currentConnections: Connection[] = [];
   private selectedDataservice: Dataservice;
   private selectedConnection: Connection;
   private connectionForSchemaRegen = "";
+  private newlyAddedDataservice = "";
+  private newlyAddedDataserviceCreateTime = 0;
 
   constructor() {
     // Nothing to do
@@ -170,6 +174,39 @@ export class WizardService {
    */
   public setConnectionIdForSchemaRegen(connectionName: string): void {
     this.connectionForSchemaRegen = connectionName !== null ? connectionName : "";
+  }
+
+  /**
+   * Get name of a newly added dataservice.  If the wait time after create has been exceeded,
+   * it is no longer considered a new service.
+   * @returns {string} the name of the newly added dataservice
+   */
+  public getNewlyAddedDataservice(): string {
+    // New service not set - just return
+    if (this.newlyAddedDataservice.length === 0) {
+      return this.newlyAddedDataservice;
+    }
+
+    // New service set - check wait time.  If wait time expired, reset name.
+    const waitSinceCreate = Date.now() - this.newlyAddedDataserviceCreateTime;
+    if (waitSinceCreate > WizardService.newlyAddedServiceWaitMillis) {
+      this.newlyAddedDataservice = "";
+    }
+    return this.newlyAddedDataservice;
+  }
+
+  /**
+   * Set the name of a newly added service.
+   * @param {string} dataserviceName the name of the newly added dataservice
+   */
+  public setNewlyAddedDataservice(dataserviceName: string): void {
+    // If non-empty name, set it the name and the creation time.
+    if (dataserviceName !== null && dataserviceName.length > 0) {
+      this.newlyAddedDataservice = dataserviceName;
+      this.newlyAddedDataserviceCreateTime = Date.now();
+    } else {
+      this.newlyAddedDataservice = "";
+    }
   }
 
   /**

--- a/src/main/ngapp/src/app/shared/test-data.service.ts
+++ b/src/main/ngapp/src/app/shared/test-data.service.ts
@@ -40,6 +40,8 @@ export class TestDataService {
   private static readonly catalogSourceId1 = "postgresql-persistent-j9vqv";
   private static readonly catalogSourceId2 = "postgresql-persistent-a8xrt";
   private static readonly catalogSourceId3 = "mysql-persistent-t3irv";
+  private static readonly catalogSourceId4 = "mongodb-persistent-x9prt";
+  private static readonly catalogSourceId5 = "mongodb-persistent-z8amy";
 
   // =================================================================
   // VDBs
@@ -190,6 +192,16 @@ export class TestDataService {
     TestDataService.catalogSourceId3,
     TestDataService.catalogSourceId3,
     "mysql",
+    true );
+  private static catalogSourceMongo1 = TestDataService.createServiceCatalogSource(
+    TestDataService.catalogSourceId4,
+    TestDataService.catalogSourceId4,
+    "mongodb",
+    true );
+  private static catalogSourceMongo2 = TestDataService.createServiceCatalogSource(
+    TestDataService.catalogSourceId5,
+    TestDataService.catalogSourceId5,
+    "mongodb",
     true );
 
   // =================================================================
@@ -906,7 +918,9 @@ export class TestDataService {
     TestDataService.pgConnCatalogSource,
     TestDataService.catalogSource1,
     TestDataService.catalogSource2,
-    TestDataService.catalogSource3];
+    TestDataService.catalogSource3,
+    TestDataService.catalogSourceMongo1,
+    TestDataService.catalogSourceMongo2];
 
   private connections: Connection[] = [
     TestDataService.pgConn,


### PR DESCRIPTION
- uncomments the mongo source type in ConnectionService, so that it shows up as a selectable type in the connection wizard.  Added a couple mongo serviceCatalog datasources in the TestData service.
- TEIIDTOOLS-417 - made some changes to address issue where status momentarily goes to 'error' (not found) when virtualization is first created.  If the status is updated too quickly when a dataservice is created, the vdb deployment has not yet started.  I added 'newlyCreatedService' function in the wizard service, which is set when the deployment is initiated.  The status page checks for newlyCreatedService and will not update its status.  The wizardService changes the 'newlyCreated' designation after a 5sec wait, at which time the status gets updated.  