### PR TITLE
TEIIDTOOLS-390 Improve page background color consistency

### DIFF
--- a/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.css
+++ b/src/main/ngapp/src/app/connections/add-connection-wizard/add-connection-wizard.component.css
@@ -16,3 +16,15 @@
   font-size: 67px;
   line-height: 67px;
 }
+
+.modal-header {
+  background-color: #fff;
+}
+
+.wizard-pf-body {
+  background: var(--page-background-color);
+}
+
+.wizard-pf-steps-indicator {
+  border-top: 0;
+}

--- a/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.css
+++ b/src/main/ngapp/src/app/dataservices/add-dataservice-wizard/add-dataservice-wizard.component.css
@@ -39,3 +39,15 @@
   -moz-border-radius: 2px;
   border-radius: 2px;
 }
+
+.modal-header {
+  background-color: #fff;
+}
+
+.wizard-pf-body {
+  background: var(--page-background-color);
+}
+
+.wizard-pf-steps-indicator {
+  border-top: 0;
+}


### PR DESCRIPTION
Changes the add-connection and add-virtualization wizard styles.  The body background color is set to the same as the summary card view pages.  Also improved the wizard header background color and divider