### PR TITLE
TEIIDTOOLS-447: Adds extra error information for odata metadata fetching

### DIFF
--- a/src/main/ngapp/src/app/dataservices/odata-control/odata-constants.ts
+++ b/src/main/ngapp/src/app/dataservices/odata-control/odata-constants.ts
@@ -66,6 +66,9 @@ export class OdataConstants {
   public readonly searchErrorMsg = "Error: failed to get any results: ";
   public readonly whereErrorMsg = "The chosen column has a type which cannot be used in a where condition";
   public readonly metadataFetchFailure = "Failed to get the odata metadata for the published artifact.";
+  public readonly metadataFetchFailureNoOdataRoot = "No route url could be detected. Please check your Openshift installation.";
+  public readonly metadataFetchFailureNoViewModel = "No view model is available within the selected dataservice.";
+  public readonly metadataFetchFailureUrl = "Try to navigate to the following url to check for a problem:";
 
   public readonly help_endpointSubmit = "This URL is formed using the OData specification. It can be copied into a new browser window to return the results in xml format or append ?format=json to the URL for JSON.  Click the Submit button to display the results in a formatted table.";
   public readonly help_select = "Choose the view from which results should be sought. Select a limit to curtail the number of results returned ";

--- a/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.css
+++ b/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.css
@@ -252,3 +252,7 @@
   font-weight: bold;
   padding-left: 7em;
 }
+
+#odata-metadata-fetch-failure h3 {
+  line-height: 150%;
+}

--- a/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.html
+++ b/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.html
@@ -215,6 +215,6 @@
 	</div>
 
 	<div id="odata-metadata-fetch-failure" class="col-sm-12" [hidden]="!metadataFailure">
-	  <h3>{{i18n.metadataFetchFailure}}</h3>
+	  <h3 [innerHTML]="metadataFailureMsg"></h3>
 	</div>
 </div>

--- a/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.ts
+++ b/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.ts
@@ -101,6 +101,10 @@ export class OdataControlComponent implements OnChanges {
     return this.dataservice.getOdataRootUrl() + '/' + this.dataservice.getServiceViewModel();
   }
 
+  public get metadataUrl(): string {
+    return this.rootUrl + '/$metadata';
+  }
+
   public ngOnChanges(changes: SimpleChanges): void {
     this.dataservice = this.dataserviceService.getSelectedDataservice();
 
@@ -113,7 +117,7 @@ export class OdataControlComponent implements OnChanges {
 
     this.results = null;
 
-    const url = this.rootUrl + '/$metadata';
+    const url = this.metadataUrl;
 
     this.metadataFetchInProgress = true;
     this.dataserviceService.odataGet(url)
@@ -132,7 +136,7 @@ export class OdataControlComponent implements OnChanges {
         (error) => {
           this.odata.metadataFailure = true;
           this.metadataFetchInProgress = false;
-          console.error('Failed to get odata metadata ' + error);
+          console.error('Failed to get odata metadata from\n' + url + "\n" + error);
         }
       );
   }
@@ -198,6 +202,19 @@ export class OdataControlComponent implements OnChanges {
 
   public get metadataFailure(): boolean {
     return this.odata.metadataFailure;
+  }
+
+  public get metadataFailureMsg(): string {
+    let msg = this.i18n.metadataFetchFailure + '<br/>';
+    if (_.isEmpty(this.dataservice.getOdataRootUrl()))
+      return msg + this.i18n.metadataFetchFailureNoOdataRoot;
+
+    if (_.isEmpty(this.dataservice.getServiceViewModel()))
+      return msg + this.i18n.metadataFetchFailureNoViewModel;
+
+
+    return msg + this.i18n.metadataFetchFailureUrl + '<br/>' +
+      '<a href="' + this.metadataUrl + '">' + this.metadataUrl + '</a>';
   }
 
   /**


### PR DESCRIPTION
* Should the odata metadata fetching fail, it should be possible to try
  and navigate to the metadata url to help diagnose the issue, eg. domain
  problem, certificate failure.

* Improves the failure message to provide better error messaging for fail
  scenarios.