### PR TITLE
Started work on the property editors area and some i18n

### DIFF
--- a/src/main/ngapp/src/app/dataservices/dataservices.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.module.ts
@@ -70,6 +70,7 @@ import { VirtualizationComponent } from "./virtualization/virtualization.compone
 import { ConnectionTreeSelectorComponent } from './virtualization/view-editor/connection-table-dialog/connection-tree-selector/connection-tree-selector.component';
 import { ConnectionTableDialogComponent } from './virtualization/view-editor/connection-table-dialog/connection-table-dialog.component';
 import { ProgressDialogComponent } from "@shared/progress-dialog/progress-dialog.component";
+import { ViewPropertyEditorsComponent } from './virtualization/view-editor/view-property-editors/view-property-editors.component';
 
 @NgModule({
   imports: [
@@ -119,7 +120,8 @@ import { ProgressDialogComponent } from "@shared/progress-dialog/progress-dialog
     MessageLogComponent,
     EditorViewsComponent,
     ConnectionTreeSelectorComponent,
-    ConnectionTableDialogComponent
+    ConnectionTableDialogComponent,
+    ViewPropertyEditorsComponent
   ],
   providers: [
     {

--- a/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.ts
+++ b/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.ts
@@ -205,13 +205,12 @@ export class OdataControlComponent implements OnChanges {
   }
 
   public get metadataFailureMsg(): string {
-    let msg = this.i18n.metadataFetchFailure + '<br/>';
+    const msg = this.i18n.metadataFetchFailure + '<br/>';
     if (_.isEmpty(this.dataservice.getOdataRootUrl()))
       return msg + this.i18n.metadataFetchFailureNoOdataRoot;
 
     if (_.isEmpty(this.dataservice.getServiceViewModel()))
       return msg + this.i18n.metadataFetchFailureNoViewModel;
-
 
     return msg + this.i18n.metadataFetchFailureUrl + '<br/>' +
       '<a href="' + this.metadataUrl + '">' + this.metadataUrl + '</a>';

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/command-factory.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/command-factory.ts
@@ -184,10 +184,10 @@ export class CommandFactory {
 
         for ( const entry of json[ Command.argsPropJson ] ) {
           if ( entry[ Command.argNameJson ] === UpdateViewNameCommand.newName ) {
-            newViewName = entry[ "value" ];
+            newViewName = entry[ Command.argValueJson ];
           }
           else if ( entry[ Command.argNameJson ] === UpdateViewNameCommand.oldName ) {
-            replacedViewName = entry[ "value" ];
+            replacedViewName = entry[ Command.argValueJson ];
           }
 
           if ( newViewName && replacedViewName ) {

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/connection-table-dialog/connection-table-dialog.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/connection-table-dialog/connection-table-dialog.component.html
@@ -5,12 +5,12 @@
   </button>
 </div>
 <div class="modal-body">
-  <strong>Expand connection and select a source for your view</strong>
+  <strong>{{message}}</strong>
   <app-connection-tree-selector
     (nodeSelected)="onTreeNodeSelected($event)"
     (nodeDeselected)="onTreeNodeDeselected($event)"></app-connection-tree-selector>
   <div>
-    <h4>Current Selection:</h4>
+    <h4>{{currentSelectionMsg}}</h4>
     <strong>{{ selectionText }}</strong>
   </div>
 </div>

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/connection-table-dialog/connection-table-dialog.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/connection-table-dialog/connection-table-dialog.component.ts
@@ -25,6 +25,7 @@ import { ConnectionsConstants } from "@connections/shared/connections-constants"
 import { LoadingState } from "@shared/loading-state.enum";
 import { ConnectionService } from "@connections/shared/connection.service";
 import { LoggerService } from "@core/logger.service";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 
 @Component({
   selector: "app-connection-table-dialog",
@@ -52,12 +53,14 @@ export class ConnectionTableDialogComponent implements OnInit {
 
   @Output() public okAction = new EventEmitter();
 
-  public title = "Select Source for View";
-  public cancelButtonText = "Cancel";
-  public okButtonText = "OK";
+  public readonly title = ViewEditorI18n.connectionTableSelectionDialogTitle;
+  public readonly message = ViewEditorI18n.connectionTableSelectionDialogMessage;
+  public readonly cancelButtonText = ViewEditorI18n.cancelButtonText;
+  public readonly okButtonText = ViewEditorI18n.okButtonText;
   public okButtonEnabled = false;
   public bsModalRef: BsModalRef;
-  public selectionText = "Nothing selected";
+  public selectionText = ViewEditorI18n.noSelection;
+  public readonly currentSelectionMsg = ViewEditorI18n.currentSelection;
 
   private connectionService: ConnectionService;
   private selectedTreeNodes: SchemaNode[] = [];

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/connection-table-dialog/connection-tree-selector/connection-tree-selector.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/connection-table-dialog/connection-tree-selector/connection-tree-selector.component.spec.ts
@@ -10,7 +10,7 @@ import { VdbService } from "@dataservices/shared/vdb.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { AppSettingsService } from "@core/app-settings.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
-import { SchemaNode } from "@connections/shared/schema-node.model";
+import { MockAppSettingsService } from "@core/mock-app-settings.service";
 
 describe("ConnectionTreeSelectorComponent", () => {
   let component: ConnectionTreeSelectorComponent;
@@ -20,7 +20,10 @@ describe("ConnectionTreeSelectorComponent", () => {
     TestBed.configureTestingModule({
       imports: [ HttpModule, TreeModule ],
       declarations: [ ConnectionTreeSelectorComponent ],
-      providers: [ AppSettingsService, LoggerService, NotifierService,
+      providers: [
+        { provide: AppSettingsService, useClass: MockAppSettingsService },
+        LoggerService,
+        NotifierService,
         { provide: ConnectionService, useClass: MockConnectionService },
         { provide: VdbService, useClass: MockVdbService },
       ]

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/editor-views.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/editor-views.component.html
@@ -4,7 +4,7 @@
        (deselect)="tabSelected(tabs[0], false)">
     <ng-template tabHeading>
       <span class="fa fa-list-alt editor-views-tab-icon"></span>
-      <span class="editor-views-tab-heading">Preview</span>
+      <span class="editor-views-tab-heading">{{previewTabName}}</span>
     </ng-template>
     <app-view-preview></app-view-preview>
   </tab>
@@ -13,7 +13,7 @@
        (deselect)="tabSelected(tabs[1], false)">
     <ng-template tabHeading>
       <span class="pficon pficon-info editor-views-tab-icon"></span>
-      <span class="editor-views-tab-heading">Messages</span>
+      <span class="editor-views-tab-heading">{{messagesTabName}}</span>
     </ng-template>
     <app-message-log></app-message-log>
   </tab>

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message-log.component.css
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message-log.component.css
@@ -1,5 +1,5 @@
 /*
- * The container for the mesage log table.
+ * The container for the message log table.
  */
 #view-editor-message-log {
   align-items: center;

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message-log.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message-log.component.ts
@@ -20,6 +20,7 @@ import { LoggerService } from "@core/logger.service";
 import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
 import { EmptyStateConfig, NgxDataTableConfig, TableConfig } from "patternfly-ng";
 import { Message } from "@dataservices/virtualization/view-editor/editor-views/message-log/message";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -49,19 +50,19 @@ export class MessageLogComponent implements OnInit {
   public ngOnInit(): void {
     this.columns = [
       {
-        name: "ID",
+        name: ViewEditorI18n.idColumnName,
         prop: Message.ID_PROP_NAME
       },
       {
-        name: "Type",
+        name: ViewEditorI18n.typeColumnName,
         prop: Message.TYPE_PROP_NAME
       },
       {
-        name: "Description",
+        name: ViewEditorI18n.descriptionColumnName,
         prop: Message.DESCRIPTION_PROP_NAME
       },
       {
-        name: "Context",
+        name: ViewEditorI18n.contextColumnName,
         prop: Message.CONTEXT_PROP_NAME
       },
     ];
@@ -74,7 +75,7 @@ export class MessageLogComponent implements OnInit {
     } as NgxDataTableConfig;
 
     this.emptyStateConfig = {
-      title: "No messages found"
+      title: ViewEditorI18n.noMessagesFound
     } as EmptyStateConfig;
 
     this.tableConfig = {

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/problem.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/problem.ts
@@ -15,18 +15,13 @@
  * limitations under the License.
  */
 import { MessageType } from "@dataservices/virtualization/view-editor/editor-views/message-log/message-type.enum";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 
 export class Problem {
 
-  public static readonly ERR0100 = new Problem( "ERR0100",
-                                                MessageType.ERROR,
-                                                "There must be a virtualization selected in order to use this editor." );
-  public static readonly ERR0110 = new Problem( "ERR0110",
-                                                MessageType.ERROR,
-                                                "A view must have a name." );
-  public static readonly ERR0120 = new Problem( "ERR0120",
-                                                 MessageType.ERROR,
-                                                 "A view must have at least one source." );
+  public static readonly ERR0100 = new Problem( "ERR0100", MessageType.ERROR, ViewEditorI18n.error0100 );
+  public static readonly ERR0110 = new Problem( "ERR0110", MessageType.ERROR, ViewEditorI18n.error0110 );
+  public static readonly ERR0120 = new Problem( "ERR0120", MessageType.ERROR, ViewEditorI18n.error0120 );
 
   private readonly _id: string;
   private readonly _description: string;

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component.ts
@@ -24,6 +24,7 @@ import { ColumnData } from "@dataservices/shared/column-data.model";
 import { RowData } from "@dataservices/shared/row-data.model";
 import { EmptyStateConfig, NgxDataTableConfig, TableConfig } from "patternfly-ng";
 import { Subscription } from "rxjs/Subscription";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -102,7 +103,7 @@ export class ViewPreviewComponent implements OnInit, OnDestroy {
     } as NgxDataTableConfig;
 
     this.emptyStateConfig = {
-      title: "Preview data unavailable"
+      title: ViewEditorI18n.previewDataUnavailable
     } as EmptyStateConfig;
 
     this.tableConfig = {
@@ -129,7 +130,7 @@ export class ViewPreviewComponent implements OnInit, OnDestroy {
 
     // Define the row data
     let firstTime = true;
-    const rowNumHeader = "ROW #";
+    const rowNumHeader = ViewEditorI18n.rowNumberColumnName;
 
     for ( let rowIndex = 0; rowIndex < rowData.length; rowIndex++ ) {
       const row = rowData[ rowIndex ];

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-save-progress-change-id.enum.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-save-progress-change-id.enum.ts
@@ -20,7 +20,7 @@ export enum ViewEditorSaveProgressChangeId {
   /**
    * Indicates the view save is in progress.
    */
-  IN_PROGESS = "IN_PROGRESS",
+  IN_PROGRESS = "IN_PROGRESS",
 
   /**
    * Indicates the view save has completed successfully.

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.html
@@ -8,7 +8,7 @@
       <div class="alert-padding" *ngIf="!hasViewSources">
         <div class="alert alert-info text-center">
           <span class="pficon pficon-info"></span>
-          <strong>Select a source for the view</strong>
+          <strong>{{noSourcesAlert}}</strong>
         </div>
       </div>
       <div class="object-card-container" *ngIf="hasViewSources">
@@ -20,7 +20,8 @@
   <!-- ========== Properties ========== -->
   <!-- ================================ -->
   <div class="view-editor-area"
-       id="view-editor-properties-container">Properties
+       id="view-editor-properties-container">
+    <app-view-property-editors></app-view-property-editors>
   </div>
 
 </div>

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.spec.ts
@@ -19,6 +19,8 @@ import {
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
+import { ViewPropertyEditorsComponent } from "@dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component";
+import { TabsModule } from "ngx-bootstrap";
 
 describe('ViewCanvasComponent', () => {
   let component: ViewCanvasComponent;
@@ -36,9 +38,14 @@ describe('ViewCanvasComponent', () => {
         SortModule,
         TableModule,
         WizardModule,
-        HttpModule
+        HttpModule,
+        TabsModule.forRoot()
       ],
-      declarations: [ ViewCanvasComponent, SelectedNodeComponent ],
+      declarations: [
+        SelectedNodeComponent,
+        ViewCanvasComponent,
+        ViewPropertyEditorsComponent
+      ],
       providers: [
         { provide: AppSettingsService, useClass: MockAppSettingsService },
         LoggerService,

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.ts
@@ -23,6 +23,7 @@ import { Subscription } from "rxjs/Subscription";
 import { SchemaNode } from "@connections/shared/schema-node.model";
 import { ViewEditorPart } from "@dataservices/virtualization/view-editor/view-editor-part.enum";
 import { ViewStateChangeId } from "@dataservices/virtualization/view-editor/event/view-state-change-id.enum";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -31,6 +32,9 @@ import { ViewStateChangeId } from "@dataservices/virtualization/view-editor/even
   styleUrls: ["./view-canvas.component.css"]
 })
 export class ViewCanvasComponent implements OnInit, OnDestroy {
+
+  // used by html
+  public readonly noSourcesAlert = ViewEditorI18n.noSourcesAlert;
 
   private readonly logger: LoggerService;
   private readonly editorService: ViewEditorService;

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.html
@@ -19,13 +19,13 @@
   <div class="form-group">
     <label class="col-sm-2 control-label view-editor-header-label required-field"
            id="view-editor-header-name"
-           for="view-name-input">View Name:
+           for="view-name-input">{{viewNameLabel}}
     </label>
     <div class="col-sm-5 view-editor-header-input-div">
       <input type="text"
              id="view-name-input"
              name="view-name-input"
-             placeholder="Enter a view name"
+             placeholder={{viewNamePlaceholder}}
              autofocus
              [(ngModel)]="viewName"
              [readonly]="readOnly"
@@ -41,7 +41,7 @@
            for="view-editor-header-show-description">
       <input type="checkbox"
              id="view-editor-header-show-description"
-             (change)="showDescription = $event.target.checked">Show Description
+             (change)="showDescription = $event.target.checked">{{showDescriptionCheckbox}}
     </label>
   </div>
 
@@ -52,13 +52,13 @@
        *ngIf="showDescription">
     <label class="col-sm-2 control-label view-editor-header-label"
            id="view-editor-header-description"
-           for="view-editor-header-description-input">Description:
+           for="view-editor-header-description-input">{{descriptionLabel}}
     </label>
     <div class="col-sm-7 view-editor-header-input-div">
         <textarea class="form-control"
                   id="view-editor-header-description-input"
                   name="view-editor-header-description-input"
-                  placeholder="Enter a view description"
+                  placeholder={{descriptionPlaceholder}}
                   [(ngModel)]="viewDescription"
                   [readonly]="readOnly"
                   (input)="viewDescriptionChanged($event.target.value)"

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
@@ -22,6 +22,7 @@ import { ViewEditorService } from "@dataservices/virtualization/view-editor/view
 import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
 import { ViewStateChangeId } from "@dataservices/virtualization/view-editor/event/view-state-change-id.enum";
 import { Subscription } from "rxjs/Subscription";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -30,6 +31,13 @@ import { Subscription } from "rxjs/Subscription";
   styleUrls: ["./view-editor-header.component.css"]
 })
 export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
+
+  // used by html
+  public readonly descriptionLabel = ViewEditorI18n.descriptionLabel;
+  public readonly descriptionPlaceholder = ViewEditorI18n.descriptionPlaceholder;
+  public readonly showDescriptionCheckbox = ViewEditorI18n.showDescriptionCheckbox;
+  public readonly viewNameLabel = ViewEditorI18n.viewNameLabel;
+  public readonly viewNamePlaceholder = ViewEditorI18n.viewNamePlaceholder;
 
   private readonly logger: LoggerService;
   private readonly editorService: ViewEditorService;

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-i18n.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-i18n.ts
@@ -17,11 +17,80 @@
 
 export class ViewEditorI18n {
 
+  // shared
+  public static readonly cancelButtonText = "Cancel";
+  public static readonly okButtonText = "OK";
+
   // commands
   public static readonly addSourceCommandName = "Add Source";
   public static readonly removeSourceCommandName = "Remove Source";
-  public static readonly replaceSourceCommandName = "Replace Source";
   public static readonly updateViewNameCommandName = "Update View Name";
   public static readonly updateViewDescriptionCommandName = "Update View Description";
+
+  // connection table dialog
+  public static readonly connectionTableSelectionDialogMessage = "Expand connection and select a source for your view";
+  public static readonly connectionTableSelectionDialogTitle = "Select Source for View";
+  public static readonly currentSelection = "Current Selection:";
+  public static readonly noSelection = "Nothing selected";
+
+  // editor views
+  public static readonly messagesTabName = "Messages";
+  public static readonly previewTabName = "Preview";
+
+  // message log
+  public static readonly contextColumnName = "Context";
+  public static readonly descriptionColumnName = "Description";
+  public static readonly idColumnName = "ID";
+  public static readonly noMessagesFound = "No messages found";
+  public static readonly typeColumnName = "Type";
+
+  // problems
+  public static readonly error0100 = "There must be a virtualization selected in order to use this editor.";
+  public static readonly error0110 = "A view must have a name.";
+  public static readonly error0120 = "A view must have at least one source.";
+
+  // property editors
+  public static readonly columnPropsTabName = "Column";
+  public static readonly viewPropsTabName = "View";
+
+  // view canvas
+  public static readonly noSourcesAlert = "Select a source for the view";
+
+  // view editor
+  public static readonly addCompositionActionTitle = "Add Composition";
+  public static readonly addCompositionActionTooltip = "Add Composition";
+  public static readonly addSourceDialogTitle = "Select View Source";
+  public static readonly addSourceActionTitle = "Add Source";
+  public static readonly addSourceActionTooltip = "Add Source";
+  public static readonly deleteActionTitle = "Delete";
+  public static readonly deleteActionTooltip = "Delete the selection(s)";
+  public static readonly errorsActionTitle = "Errors";
+  public static readonly errorsActionTooltip = "Show error messages";
+  public static readonly infosActionTitle = "Infos";
+  public static readonly infosActionTooltip = "Show info messages";
+  public static readonly redoActionTitle = "Redo";
+  public static readonly redoActionTooltip = "Redo";
+  public static readonly saveActionTitle = "Save";
+  public static readonly saveActionTooltip = "Save";
+  public static readonly saveProgressDialogMessage = "Saving View in Progress...";
+  public static readonly saveProgressDialogTitle = "Saving View";
+  public static readonly showEditorCanvasAndViewsActionTooltip = "Show full editor";
+  public static readonly showEditorCanvasOnlyActionTooltip = "Show canvas and properties only";
+  public static readonly showEditorViewsOnlyActionTooltip = "Show information views only";
+  public static readonly undoActionTitle = "Undo";
+  public static readonly undoActionTooltip = "Undo";
+  public static readonly warningsActionTitle = "Warnings";
+  public static readonly warningsActionTooltip = "Show warning messages";
+
+  // view editor header
+  public static readonly descriptionLabel = "Description:";
+  public static readonly descriptionPlaceholder = "Enter a view description";
+  public static readonly showDescriptionCheckbox = "Show Description";
+  public static readonly viewNameLabel = "View Name:";
+  public static readonly viewNamePlaceholder = "Enter a view name";
+
+  // view preview
+  public static readonly previewDataUnavailable = "Preview data unavailable";
+  public static readonly rowNumberColumnName = "ROW #";
 
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.spec.ts
@@ -1,10 +1,16 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from "@angular/forms";
 import { RouterTestingModule } from "@angular/router/testing";
+import { ConnectionService } from "@connections/shared/connection.service";
+import { MockConnectionService } from "@connections/shared/mock-connection.service";
 import { CoreModule } from "@core/core.module";
 import { AppSettingsService } from "@core/app-settings.service";
+import { MockAppSettingsService } from "@core/mock-app-settings.service";
 import { SelectionService } from "@core/selection.service";
 import { SelectedNodeComponent } from "@dataservices/selected-node/selected-node.component";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
 import { ViewEditorComponent } from '@dataservices/virtualization/view-editor/view-editor.component';
 import { ViewCanvasComponent } from "@dataservices/virtualization/view-editor/view-canvas/view-canvas.component";
 import { ConnectionTableDialogComponent } from "@dataservices/virtualization/view-editor/connection-table-dialog/connection-table-dialog.component";
@@ -13,6 +19,7 @@ import { EditorViewsComponent } from "@dataservices/virtualization/view-editor/e
 import { MessageLogComponent } from "@dataservices/virtualization/view-editor/editor-views/message-log/message-log.component";
 import { ViewPreviewComponent } from "@dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component";
 import { ViewEditorHeaderComponent } from "@dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component";
+import { ViewPropertyEditorsComponent } from "@dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component";
 import { TreeModule } from "angular-tree-component";
 import { TabsModule } from "ngx-bootstrap";
 import {
@@ -26,12 +33,6 @@ import {
   TableModule,
   ToolbarModule,
   WizardModule } from "patternfly-ng";
-import { VdbService } from "@dataservices/shared/vdb.service";
-import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
-import { MockAppSettingsService } from "@core/mock-app-settings.service";
-import { NotifierService } from "@dataservices/shared/notifier.service";
-import { ConnectionService } from "@connections/shared/connection.service";
-import { MockConnectionService } from "@connections/shared/mock-connection.service";
 
 describe('ViewEditorComponent', () => {
   let component: ViewEditorComponent;
@@ -65,7 +66,8 @@ describe('ViewEditorComponent', () => {
         ViewCanvasComponent,
         ViewEditorComponent,
         ViewEditorHeaderComponent,
-        ViewPreviewComponent
+        ViewPreviewComponent,
+        ViewPropertyEditorsComponent
       ],
       providers: [
         { provide: AppSettingsService, useClass: MockAppSettingsService },

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.ts
@@ -36,6 +36,7 @@ import { Action, ActionConfig, ToolbarConfig, ToolbarView } from "patternfly-ng"
 import { Subscription } from "rxjs/Subscription";
 import { ViewEditorSaveProgressChangeId } from "@dataservices/virtualization/view-editor/event/view-editor-save-progress-change-id.enum";
 import { ProgressDialogComponent } from "@shared/progress-dialog/progress-dialog.component";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -65,7 +66,7 @@ export class ViewEditorComponent implements DoCheck, OnDestroy, OnInit {
   //
   private readonly canvasOnlyCssType = "view-editor-canvas-only";
   private readonly fullEditorCssType = "view-editor-full";
-  private readonly resultsOnlyCssType = "view-editor-views-only";
+  private readonly viewsOnlyCssType = "view-editor-views-only";
 
   //
   // Toolbar action IDs
@@ -148,9 +149,9 @@ export class ViewEditorComponent implements DoCheck, OnDestroy, OnInit {
   private doAddSource(): void {
     // Open Source selection dialog
     const initialState = {
-      title: "Select View Source",
-      cancelButtonText: "Cancel",
-      okButtonText: "OK"
+      title: ViewEditorI18n.addSourceDialogTitle,
+      cancelButtonText: ViewEditorI18n.cancelButtonText,
+      okButtonText: ViewEditorI18n.okButtonText
     };
 
     // Show Dialog, act upon confirmation click
@@ -261,67 +262,67 @@ export class ViewEditorComponent implements DoCheck, OnDestroy, OnInit {
             disabled: !this.canAddSource(),
             id: this.addSourceActionId,
             template: addSourceTemplate,
-            title: "Add Source",
-            tooltip: "Add Source"
+            title: ViewEditorI18n.addSourceActionTitle,
+            tooltip: ViewEditorI18n.addSourceActionTooltip
           },
           {
             disabled: !this.canAddComposition(),
             id: this.addCompositionActionId,
             template: addCompositionTemplate,
-            title: "Add Composition",
-            tooltip: "Add Composition"
+            title: ViewEditorI18n.addCompositionActionTitle,
+            tooltip: ViewEditorI18n.addCompositionActionTooltip
           },
           {
             disabled: !this.canSave(),
             id: this.saveActionId,
             styleClass: "view-editor-toolbar-end-group",
             template: saveTemplate,
-            title: "Save",
-            tooltip: "Save"
+            title: ViewEditorI18n.saveActionTitle,
+            tooltip: ViewEditorI18n.saveActionTooltip
           },
           {
             disabled: !this.canUndo(),
             id: this.undoActionId,
             template: undoTemplate,
-            title: "Undo",
-            tooltip: "Undo"
+            title: ViewEditorI18n.undoActionTitle,
+            tooltip: ViewEditorI18n.undoActionTooltip
           },
           {
             disabled: !this.canRedo(),
             id: this.redoActionId,
             styleClass: "view-editor-toolbar-end-group",
             template: redoTemplate,
-            title: "Redo",
-            tooltip: "Redo"
+            title: ViewEditorI18n.redoActionTitle,
+            tooltip: ViewEditorI18n.redoActionTooltip
           },
           {
             disabled: !this.canDelete(),
             id: this.deleteActionId,
             styleClass: "view-editor-toolbar-end-group",
             template: deleteTemplate,
-            title: "Delete",
-            tooltip: "Delete the selection"
+            title: ViewEditorI18n.deleteActionTitle,
+            tooltip: ViewEditorI18n.deleteActionTooltip
           },
           {
             disabled: !this.hasErrors(),
             id: this.errorsActionId,
             template: errorsTemplate,
-            title: "Errors",
-            tooltip: "Error messages"
+            title: ViewEditorI18n.errorsActionTitle,
+            tooltip: ViewEditorI18n.errorsActionTooltip
           },
           {
             disabled: !this.hasWarnings(),
             id: this.warningsActionId,
             template: warningsTemplate,
-            title: "Warnings",
-            tooltip: "Warning messages"
+            title: ViewEditorI18n.warningsActionTitle,
+            tooltip: ViewEditorI18n.warningsActionTooltip
           },
           {
             disabled: !this.hasInfos(),
             id: this.infosActionId,
             template: infosTemplate,
-            title: "Infos",
-            tooltip: "Info messages"
+            title: ViewEditorI18n.infosActionTitle,
+            tooltip: ViewEditorI18n.infosActionTooltip
           }
         ],
         moreActions: [],
@@ -387,12 +388,11 @@ export class ViewEditorComponent implements DoCheck, OnDestroy, OnInit {
     } else if ( event.typeIsEditorViewSaveProgressChanged() ) {
       if ( event.args.length !== 0 ) {
         // When save in progress, open the progress modal dialog.  On completion, hide it
-        if ( event.args[ 0 ] === ViewEditorSaveProgressChangeId.IN_PROGESS ) {
+        if ( event.args[ 0 ] === ViewEditorSaveProgressChangeId.IN_PROGRESS ) {
           // Dialog Content
-          const message = "Saving View in Progress...";
           const initialState = {
-            title: "Saving View",
-            bodyContent: message,
+            title: ViewEditorI18n.saveProgressDialogTitle,
+            bodyContent: ViewEditorI18n.saveProgressDialogMessage,
           };
 
           this.progressModalRef = this.modalService.show(ProgressDialogComponent, {initialState});
@@ -432,7 +432,7 @@ export class ViewEditorComponent implements DoCheck, OnDestroy, OnInit {
    * @returns {boolean} `true` if area should be shown
    */
   public get isShowingAdditionalViews(): boolean {
-    return this.editorCssType === this.resultsOnlyCssType || this.editorCssType === this.fullEditorCssType;
+    return this.editorCssType === this.viewsOnlyCssType || this.editorCssType === this.fullEditorCssType;
   }
 
   /**
@@ -480,17 +480,17 @@ export class ViewEditorComponent implements DoCheck, OnDestroy, OnInit {
         {
           id: this.fullEditorCssType,
           iconStyleClass: "fa fa-file-text-o",
-          tooltip: "Show editor and results"
+          tooltip: ViewEditorI18n.showEditorCanvasAndViewsActionTooltip
         },
         {
           id: this.canvasOnlyCssType,
           iconStyleClass: "fa fa-file-image-o",
-          tooltip: "Show editor only"
+          tooltip: ViewEditorI18n.showEditorCanvasOnlyActionTooltip
         },
         {
-          id: this.resultsOnlyCssType,
+          id: this.viewsOnlyCssType,
           iconStyleClass: "fa fa-table",
-          tooltip: "Show results only"
+          tooltip: ViewEditorI18n.showEditorViewsOnlyActionTooltip
         }
       ]
     } as ToolbarConfig;
@@ -518,7 +518,6 @@ export class ViewEditorComponent implements DoCheck, OnDestroy, OnInit {
       .subscribe(
         (connectionSummaries) => {
           const conns = [];
-          const treeNodes = [];
           for ( const connectionSummary of connectionSummaries ) {
             const connStatus = connectionSummary.getStatus();
             const conn = connectionSummary.getConnection();

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
@@ -339,7 +339,7 @@ export class ViewEditorService {
   public saveView(connections: Connection[]): void {
     // Fire save in progress event
     this.fire( ViewEditorEvent.create( ViewEditorPart.EDITOR, ViewEditorEventType.EDITOR_VIEW_SAVE_PROGRESS_CHANGED,
-                                                         [ ViewEditorSaveProgressChangeId.IN_PROGESS ] ) );
+                                                         [ ViewEditorSaveProgressChangeId.IN_PROGRESS ] ) );
 
     const serviceVdbName = this._editorVirtualization.getServiceVdbName();
     const serviceVdbModelName = this._editorVirtualization.getServiceViewModel();

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.css
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.css
@@ -1,0 +1,23 @@
+/*
+ * The editor views tabset.
+ */
+#property-editors-tabs .tab-content {
+  border: 1px solid lightgray;
+}
+
+/*
+ * Customs settings for the tab.
+ */
+#property-editors-tabs .nav-link {
+  border: 1px solid #bbbbbb;
+  border-radius: 8px 8px 0 0;
+  margin: 0;
+  padding: 4px 10px;
+}
+
+/*
+ * Custom settings for the tab heading.
+ */
+.property-editors-tab-heading {
+  font-size: smaller;
+}

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.html
@@ -1,0 +1,13 @@
+<tabset id="property-editors-tabs">
+  <tab *ngFor="let tabz of tabs"
+       [heading]="tabz.title"
+       [active]="tabz.active"
+       (select)="tabz.active = true"
+       (deselect)="tabz.active = false"
+       [disabled]="tabz.disabled"
+       [removable]="tabz.removable"
+       (removed)="removeTab(tabz)"
+       [customClass]="tabz.customClass">
+    {{tabz?.content}}
+  </tab>
+</tabset>

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.spec.ts
@@ -1,0 +1,45 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewPropertyEditorsComponent } from './view-property-editors.component';
+import { TabsModule } from "ngx-bootstrap";
+import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
+import { HttpModule } from "@angular/http";
+import { LoggerService } from "@core/logger.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { AppSettingsService } from "@core/app-settings.service";
+import { MockAppSettingsService } from "@core/mock-app-settings.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+
+describe('ViewPropertyEditorsComponent', () => {
+  let component: ViewPropertyEditorsComponent;
+  let fixture: ComponentFixture<ViewPropertyEditorsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpModule,
+        TabsModule.forRoot()
+      ],
+      declarations: [ ViewPropertyEditorsComponent ],
+      providers: [
+        { provide: AppSettingsService, useClass: MockAppSettingsService },
+        LoggerService,
+        NotifierService,
+        { provide: VdbService, useClass: MockVdbService },
+        ViewEditorService
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ViewPropertyEditorsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.ts
@@ -17,41 +17,41 @@
 
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { LoggerService } from "@core/logger.service";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
-import { ViewEditorPart } from "@dataservices/virtualization/view-editor/view-editor-part.enum";
 import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
 import { Subscription } from "rxjs/Subscription";
-import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
-  selector: 'app-editor-views',
-  templateUrl: './editor-views.component.html',
-  styleUrls: ['./editor-views.component.css']
+  selector: 'app-view-property-editors',
+  templateUrl: './view-property-editors.component.html',
+  styleUrls: ['./view-property-editors.component.css']
 })
-export class EditorViewsComponent implements OnInit, OnDestroy {
+export class ViewPropertyEditorsComponent implements OnInit, OnDestroy {
 
-  // text used by html
-  public readonly messagesTabName = ViewEditorI18n.messagesTabName;
-  public readonly previewTabName = ViewEditorI18n.previewTabName;
-
-  private readonly previewIndex = 0;
-  private readonly messagesIndex = 1;
-
+  private columnEditorIsEnabled = true;
   private readonly editorService: ViewEditorService;
   private readonly logger: LoggerService;
   private subscription: Subscription;
+  private viewEditorIsEnabled = true;
 
-  /**
-   * The tabs component configuration.
-   */
-  public tabs = [
+  public readonly tabs: any[] = [
     {
-      "active": true // preview
+      active: true,
+      content: "View properties",
+      customClass: "property-editors-tab-heading",
+      disabled: !this.viewEditorIsEnabled,
+      removable: false,
+      title: ViewEditorI18n.viewPropsTabName
     },
     {
-      "active": false // message log
-    },
+      content: "Column editor",
+      customClass: "property-editors-tab-heading",
+      disabled: !this.columnEditorIsEnabled,
+      removable: false,
+      title: ViewEditorI18n.columnPropsTabName
+    }
   ];
 
   constructor( editorService: ViewEditorService,
@@ -64,18 +64,11 @@ export class EditorViewsComponent implements OnInit, OnDestroy {
    * @param {ViewEditorEvent} event the event being processed
    */
   public handleEditorEvent( event: ViewEditorEvent ): void {
-    this.logger.debug( "EditorViewsComponent received event: " + event.toString() );
+    this.logger.debug( "ViewPropertyEditorsComponent received event: " + event.toString() );
 
-    if ( event.typeIsShowEditorPart() ) {
-      if ( event.args.length !== 0 ) {
-        if ( event.args[ 0 ] === ViewEditorPart.PREVIEW ) {
-          this.tabs[ this.messagesIndex ].active = false;
-          this.tabs[ this.previewIndex ].active = true;
-        } else if ( event.args[ 0 ] === ViewEditorPart.MESSAGE_LOG ) {
-          this.tabs[ this.previewIndex ].active = false;
-          this.tabs[ this.messagesIndex ].active = true;
-        }
-      }
+    if ( event.typeIsCanvasSelectionChanged() ) {
+      // TODO set this.viewEditorIsEnabled to true if all canvas selections are views
+      // TODO set this.columnEditorIsEnabled to true if all canvas selections are columns
     }
   }
 
@@ -94,13 +87,10 @@ export class EditorViewsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Callback for when a tab is clicked.
-   *
-   * @param tab the tab being select or deselected
-   * @param selected `true` is selected
+   * @param tab the editor tab being removed
    */
-  public tabSelected( tab, selected ): void {
-    tab.active = selected;
+  public removeTab( tab: any ): void {
+    this.tabs.splice( this.tabs.indexOf( tab ), 1);
   }
 
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-validator.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-validator.ts
@@ -42,11 +42,4 @@ export class ViewValidator {
     return messages;
   }
 
-  /**
-   * Don't allow construction outside of this class.
-   */
-  private constructor() {
-    // nothing to do
-  }
-
 }


### PR DESCRIPTION
- added initial implementation of ViewPropertyEditorsComponent that is the UI for editing view, column, and join properties
- created ViewEditorI18n to keep all text that should eventually be localized. This includes text both found in html and found in typescript files. We have been pretty lazy about i18n'ing things as of late. One reason for that is that our current way we do i18n doesn't have a way to localize text in typescript files. However, the Angular 6.0 beta (we are on 4.4) has a new i18n service that I think we can eventually use to translate this file. Hopefully once we do figure out i18n, having the text all in one place will facilitate that.
- fixed some lint errors