### PR TITLE
TEIIDTOOLS-456 - Preview VDB work

### DIFF
--- a/src/main/ngapp/src/app/connections/shared/mock-connection.service.ts
+++ b/src/main/ngapp/src/app/connections/shared/mock-connection.service.ts
@@ -147,6 +147,15 @@ export class MockConnectionService extends ConnectionService {
   }
 
   /**
+   * Update the preview VDB and re-deploy it if needed.
+   * @param {string} vdbName
+   * @returns {Observable<boolean>}
+   */
+  public refreshPreviewVdb(vdbName: string): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
    * Initiates a refresh of the connection schema via the komodo rest interface
    * @param {string} connectionName
    * @returns {Observable<boolean>}

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -75,9 +75,7 @@
           <!-- Notification for Dataservice Export -->
           <pfng-toast-notification *ngIf="showExportNotification" [header]="exportNotificationHeader"
                                  [message]="exportNotificationMessage"
-                                 [type]="exportNotificationType"
-                                 [showClose]="true"
-                                 (onCloseSelect)="onCloseExportNotification()">
+                                 [type]="exportNotificationType">
           </pfng-toast-notification>
         </div>
 

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.ts
@@ -432,10 +432,6 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
     // this.selectedServices.splice(this.selectedServices.indexOf(dataservice), 1);
   }
 
-  public onCloseExportNotification(): void {
-    this.exportNotificationVisible = false;
-  }
-
   public onActivate(svcName: string): void {
     const selectedService =  this.filteredDataservices.find((x) => x.getId() === svcName);
     selectedService.setServiceDeploymentState(DeploymentState.LOADING);
@@ -492,12 +488,16 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
             self.exportNotificationHeader = this.downloadSuccessHeader;
             self.exportNotificationMessage = "   " + svcName + " was downloaded successfully!";
             self.exportNotificationType = NotificationType.SUCCESS;
+            // Dismiss toast notification after 8 sec
+            setTimeout(() => self.exportNotificationVisible = false, 8000);
             this.logger.debug("[DataservicesPageComponent] Download Dataservice was successful");
           },
           (error) => {
             self.exportNotificationHeader = this.downloadFailedHeader;
             self.exportNotificationMessage = "   Failed to download dataservice " + svcName;
             self.exportNotificationType = NotificationType.DANGER;
+            // Dismiss toast notification after 8 sec
+            setTimeout(() => self.exportNotificationVisible = false, 8000);
             this.logger.error("[DataservicesPageComponent] Download dataservice " + svcName + " failed.");
           }
         );
@@ -522,12 +522,16 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
           self.exportNotificationHeader = this.exportSuccessHeader;
           self.exportNotificationMessage = "   " + svcName + " publishing successfully initiated.";
           self.exportNotificationType = NotificationType.INFO;
+          // Dismiss toast notification after 8 sec
+          setTimeout(() => self.exportNotificationVisible = false, 8000);
           this.logger.debug("[DataservicesPageComponent] Initiated publishing of dataservice");
         },
         (error) => {
           self.exportNotificationHeader = this.exportFailedHeader;
           self.exportNotificationMessage = "   Failed to publish dataservice " + svcName + ".";
           self.exportNotificationType = NotificationType.DANGER;
+          // Dismiss toast notification after 8 sec
+          setTimeout(() => self.exportNotificationVisible = false, 8000);
           this.logger.error("[DataservicesPageComponent] Publish dataservice " + svcName + " failed.");
         }
       );

--- a/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
@@ -35,6 +35,8 @@ import { Observable } from "rxjs/Observable";
 import { SchemaNode } from "@connections/shared/schema-node.model";
 import { Connection } from "@connections/shared/connection.model";
 import { View } from "@dataservices/shared/view.model";
+import { environment } from "@environments/environment";
+import { QueryResults } from "@dataservices/shared/query-results.model";
 
 @Injectable()
 export class MockVdbService extends VdbService {
@@ -179,6 +181,18 @@ export class MockVdbService extends VdbService {
 
   public deleteView(vdbName: string, modelName: string, viewName: string): Observable<boolean> {
     return Observable.of(true);
+  }
+
+  /**
+   * Query the vdb via the komodo rest interface
+   * @param {string} query the SQL query
+   * @param {string} vdbName the vdb name
+   * @param {number} limit the limit for the number of result rows
+   * @param {number} offset the offset for the result rows
+   * @returns {Observable<boolean>}
+   */
+  public queryVdb(query: string, vdbName: string, limit: number, offset: number): Observable<any> {
+    return Observable.of(this.testDataService.getQueryResults());
   }
 
 }

--- a/src/main/ngapp/src/app/dataservices/shared/vdbs-constants.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/vdbs-constants.ts
@@ -17,6 +17,7 @@ export class VdbsConstants {
   public static readonly SCHEMA_MODEL_SUFFIX = "schemamodel";
   public static readonly DATASERVICE_VDB_SUFFIX = "vdb";
   public static readonly DEFAULT_READONLY_DATA_ROLE = "DefaultReadOnlyDataRole";
+  public static readonly PREVIEW_VDB_NAME = "PreviewVdb";
 
   public static readonly statusPath = "/status";
 

--- a/src/main/ngapp/src/app/dataservices/shared/view.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/view.model.ts
@@ -16,6 +16,7 @@
  */
 
 import { SchemaNode } from "@connections/shared/schema-node.model";
+import { VdbsConstants } from "@dataservices/shared/vdbs-constants";
 
 /**
  * View model
@@ -82,6 +83,26 @@ export class View {
    */
   public setSources( sources: SchemaNode[] ): void {
     this.sources = sources;
+  }
+
+  /**
+   * Get the SQL for the view, given the current selections
+   * @returns {string} the view SQL
+   */
+  public getSql(): string {
+    // The view currently supports single source only
+    let sourceNodeName = "unknownSource";
+    let connectionName = "unknownConnection";
+    const source = this.getSources()[0];
+    if (source !== null) {
+      sourceNodeName = source.getName();
+      if (source.getConnectionName() !== null) {
+        connectionName = source.getConnectionName();
+      }
+    }
+
+    // Return SQL for this view
+    return "SELECT * FROM " + connectionName.toLowerCase() + VdbsConstants.SCHEMA_MODEL_SUFFIX + "." + sourceNodeName + ";";
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component.css
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component.css
@@ -23,3 +23,10 @@
   margin: 0 20px;
   width: 100%;
 }
+
+/*
+ * Style the in progress spinner
+ */
+#view-preview-in-progress {
+  margin-top: 25px;
+}

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component.html
@@ -1,11 +1,15 @@
 <div class="row" id="view-preview-container">
 
-  <pfng-table
-    id="view-preview-table"
+  <pfng-table *ngIf="!this.saveInProgress" id="view-preview-table"
     [columns]="columns"
     [config]="tableConfig"
     [dataTableConfig]="ngxConfig"
     [rows]="rows">
   </pfng-table>
 
+  <div *ngIf="this.saveInProgress" class="col-sm-2 col-sm-offset-1">
+    <span id="view-preview-in-progress" class="spinner spinner-lg spinner-inline"></span>
+  </div>
+
 </div>
+

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.css
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.css
@@ -31,3 +31,8 @@
 #view-editor-properties-container {
   grid-area: properties-editor;
 }
+
+.view-save-toast {
+  margin-left: 0.5em;
+  margin-top: 0.5em;
+}

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.html
@@ -5,6 +5,13 @@
   <!-- ============================ -->
   <div class="view-editor-area"
        id="view-editor-canvas-container">
+      <div class="view-save-toast">
+        <!-- Notification for Saving View -->
+        <pfng-toast-notification *ngIf="showSaveViewNotification" [header]="saveViewNotificationHeader"
+                                 [message]="saveViewNotificationMessage"
+                                 [type]="saveViewNotificationType">
+        </pfng-toast-notification>
+      </div>
       <div class="alert-padding" *ngIf="!hasViewSources">
         <div class="alert alert-info text-center">
           <span class="pficon pficon-info"></span>

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
@@ -30,6 +30,7 @@ import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/
 import { ViewEditorEventType } from "@dataservices/virtualization/view-editor/event/view-editor-event-type.enum";
 import { ViewStateChangeId } from "@dataservices/virtualization/view-editor/event/view-state-change-id.enum";
 import { ViewEditorSaveProgressChangeId } from "@dataservices/virtualization/view-editor/event/view-editor-save-progress-change-id.enum";
+import { VdbsConstants } from "@dataservices/shared/vdbs-constants";
 
 @Injectable()
 export class ViewEditorService {
@@ -295,6 +296,29 @@ export class ViewEditorService {
     } else {
       this._logger.debug( "setEditorVirtualization called more than once" );
     }
+  }
+
+  /**
+   * Update the preview results for the current view.  This issues a query against the preview VDB and sets
+   * the previewResults
+   */
+  public updatePreviewResults( ): void {
+    // Clear preview results
+    this.setPreviewResults(null, ViewEditorPart.EDITOR);
+
+    // Fetch new results
+    const viewSql = this._editorView.getSql();
+    const self = this;
+    // Resets all of the views in the service VDB
+    this._vdbService.queryVdb(viewSql, VdbsConstants.PREVIEW_VDB_NAME, 15, 0)
+      .subscribe(
+        (queryResult) => {
+          self.setPreviewResults(queryResult, ViewEditorPart.EDITOR);
+        },
+        (error) => {
+          alert("error getting results");
+        }
+      );
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/virtualization/virtualization.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/virtualization.component.ts
@@ -422,7 +422,12 @@ export class VirtualizationComponent implements OnInit {
     }
 
     this.currentVirtualization.setViews(virtViews);
-    this.views = this.currentVirtualization.getViews();
+    this.views = this.currentVirtualization.getViews().sort( (left, right): number => {
+      if (left.getName() < right.getName()) return -1;
+      if (left.getName() > right.getName()) return 1;
+      return 0;
+    });
+
     this.setViewsEditableState(true);
     this.viewsLoadingState = LoadingState.LOADED_VALID;
     // const self = this;


### PR DESCRIPTION
(NOTE: Need to merge the teiid-komodo companion PR when merging this)

- Adds 'refreshPreviewVdb' function in ConnectionService.  The preview vdb is refreshed whenever a connection is added/removed/updated - to keep the preview vdb in sync.
- Adds 'queryVdb' function in VdbService.  Allows submittal of SQL query against the specified VDB.
- changed the toast notifications for dataservice download and publish.  The user no longer is required to close manually - the notifications will display for 8 seconds then dismiss automatically.
- add getSql function to the ViewModel.  Generates the View SQL.
- adds submittal of preview query in view editor components.  preview panel shows a spinner while view save is in progress.  canvas shows a toast notification while view save is in progress.
