### PR TITLE
TTOOLS-464 Fixes issue with add connection wizard button sizing

### DIFF
--- a/src/main/ngapp/src/styles.css
+++ b/src/main/ngapp/src/styles.css
@@ -294,7 +294,7 @@
   width: 100%;
 }
 
-.pfng-wizard-position-override {
+.wizard-pf-body .pfng-wizard-position-override {
   height: 50vh;
   overflow-y: auto;
 }


### PR DESCRIPTION
Adjust styles.css, so that 'pfng-wizard-position-override' height property is only applied to the body - not the body and footer 