### PR TITLE
TEIIDTOOLS-467: Begins implementing remove node functionality

### DIFF
--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/add-sources-command.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/add-sources-command.ts
@@ -41,7 +41,7 @@ export class AddSourcesCommand extends Command {
    * @param {string | SchemaNode} addedSources the JSON representation of the sources or the schema nodes of the sources
    *                              being added (cannot be `null` or empty)
    */
-  public constructor( addedSources: string | SchemaNode[] ) {
+  public constructor( addedSources: string | SchemaNode[], id?: string ) {
     super( AddSourcesCommand.id, ViewEditorI18n.addSourcesCommandName );
 
     let arg: string;
@@ -66,6 +66,15 @@ export class AddSourcesCommand extends Command {
     }
 
     this._args.set( AddSourcesCommand.addedSourcePaths, arg );
+
+    if (!id) {
+      //
+      // Generate new id for this source
+      //
+      id = AddSourcesCommand.id + Date.now();
+    }
+
+    this._args.set( Command.identArg, id);
   }
 
   /**
@@ -76,4 +85,14 @@ export class AddSourcesCommand extends Command {
     return argValue.split( AddSourcesCommand.delim );
   }
 
+  /**
+   * @returns {string} a unique identifier of this command
+   */
+  public getId(sourcePath?: string): string {
+    let argValue = this.getArg( Command.identArg ) as string;
+    if (sourcePath)
+      argValue = argValue + Command.identDivider + sourcePath;
+
+    return argValue;
+  }
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/command.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/command.ts
@@ -42,6 +42,17 @@ export abstract class Command {
    */
   public static readonly idPropJson = "id";
 
+
+  /**
+   * The identifier used for the id argument
+   */
+  public static readonly identArg = "ObjectId";
+
+  /**
+   * Divider symbol between the command ident and source paths
+   */
+  public static readonly identDivider = "_-_";
+
   protected readonly _args = new Map< string, any >();
   protected readonly _id: string;
   protected readonly _name: string;

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/remove-sources-command.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/remove-sources-command.ts
@@ -41,7 +41,7 @@ export class RemoveSourcesCommand extends Command {
    * @param {string | SchemaNode} removedSources the JSON representation of the sources or the schema nodes of the sources
    *                              being removed (cannot be `null` or empty)
    */
-  public constructor( removedSources: string | SchemaNode[] ) {
+  public constructor( removedSources: string | SchemaNode[], id: string ) {
     super( RemoveSourcesCommand.id, ViewEditorI18n.removeSourcesCommandName );
 
     let arg: string;
@@ -66,6 +66,8 @@ export class RemoveSourcesCommand extends Command {
     }
 
     this._args.set( RemoveSourcesCommand.removedSourcePaths, arg );
+
+    this._args.set( Command.identArg, id);
   }
 
   /**
@@ -76,4 +78,14 @@ export class RemoveSourcesCommand extends Command {
     return argValue.split( RemoveSourcesCommand.delim );
   }
 
+  /**
+   * @returns {string} a unique identifier of this command
+   */
+  public getId(sourcePath?: string): string {
+    let argValue = this.getArg( Command.identArg ) as string;
+    if (sourcePath)
+      argValue = argValue + Command.identDivider + sourcePath;
+
+    return argValue;
+  }
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-event-type.enum.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-event-type.enum.ts
@@ -42,6 +42,11 @@ export enum ViewEditorEventType {
   CREATE_COMPOSITION = "CREATE_COMPOSITION",
 
   /**
+   * An event indicating a node should be deleted
+   */
+  DELETE_NODE = "DELETE_NODE",
+
+  /**
    * An event indicating the view being edited has been set. This will only be fired one time one the view editor is
    * opened. The one event argument is the {@link View} being set.
    *

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-event.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-event.ts
@@ -224,4 +224,11 @@ export class ViewEditorEvent {
   public typeIsCreateComposition(): boolean {
     return this.type === ViewEditorEventType.CREATE_COMPOSITION;
   }
+
+  /**
+   * @returns {boolean} `true` if the type is `ViewEditorEventType.DELETE_NODE`
+   */
+  public typeIsDeleteNode(): boolean {
+    return this.type === ViewEditorEventType.DELETE_NODE;
+  }
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/models/canvas-graph.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/models/canvas-graph.ts
@@ -171,9 +171,9 @@ export class CanvasGraph {
   /**
    * Add a new node to the graph
    */
-  public addNode(type: string, label: string, update?: boolean): CanvasNode {
+  public addNode(id: string, type: string, label: string, update?: boolean): CanvasNode {
     const isEmpty = _.isEmpty(this.nodes);
-    const canvasNode = new CanvasNode(type, label, isEmpty);
+    const canvasNode = new CanvasNode(id, type, label, isEmpty);
 
     //
     // Set as fixed by default until its linked

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/models/canvas-node.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/models/canvas-node.ts
@@ -20,8 +20,6 @@ import * as cola from 'webcola';
 
 export class CanvasNode implements cola.Node {
 
-  private static idGenerator: number = 0;
-
   // optional - defining optional implementation properties - required for relevant typing assistance
   index?: number;
   x: number;
@@ -38,8 +36,16 @@ export class CanvasNode implements cola.Node {
   private _selected: boolean = false;
   private _root: boolean = false;
 
-  constructor(type: string, label: string, root?: boolean) {
-    this._id = CanvasConstants.NODE_PREFIX + CanvasNode.idGenerator++;
+  public static encodeId(id: string): string {
+    return btoa(id);
+  }
+
+  public static decodeId(id: string): string {
+    return atob(id);
+  }
+
+  constructor(id: string, type: string, label: string, root?: boolean) {
+    this._id = CanvasNode.encodeId(id);
     this._type = type;
     this._label = label;
     if (root !== undefined)
@@ -48,6 +54,10 @@ export class CanvasNode implements cola.Node {
 
   public get id(): string {
     return this._id;
+  }
+
+  public get decodedId(): string {
+    return CanvasNode.decodeId(this.id);
   }
 
   public get type(): string {

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.ts
@@ -18,6 +18,7 @@
 import { Component, OnDestroy, OnInit, AfterViewInit, ViewEncapsulation } from "@angular/core";
 import { SchemaNode } from "@connections/shared/schema-node.model";
 import { AddSourcesCommand } from "@dataservices/virtualization/view-editor/command/add-sources-command";
+import { RemoveSourcesCommand } from "@dataservices/virtualization/view-editor/command/remove-sources-command";
 import { LoggerService } from "@core/logger.service";
 import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
 import { ViewEditorEventType } from "@dataservices/virtualization/view-editor/event/view-editor-event-type.enum";
@@ -79,7 +80,18 @@ export class ViewCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
       const srcPaths = cmd.getSourcePaths();
       for (let i = 0; i < srcPaths.length; ++i) {
         const srcPath = srcPaths[i];
-        const id = this.canvasService.createNode(CanvasConstants.SOURCE_TYPE, srcPath, i == (srcPaths.length - 1));
+        const update = (i == (srcPaths.length - 1));
+        const id = cmd.getId(srcPath);
+        this.canvasService.createNode(id, CanvasConstants.SOURCE_TYPE, srcPath, update);
+      }
+    } else if (args[0] instanceof RemoveSourcesCommand) {
+      const cmd: RemoveSourcesCommand = <RemoveSourcesCommand> args[0];
+      const srcPaths = cmd.getSourcePaths();
+      for (let i = 0; i < srcPaths.length; ++i) {
+        const srcPath = srcPaths[i];
+        const update = (i == (srcPaths.length - 1));
+        const id = cmd.getId(srcPath);
+        this.canvasService.deleteNode(id, update);
       }
     }
   }
@@ -134,6 +146,9 @@ export class ViewCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
         this.editorService.editorEvent.emit(compEvent);
         break;
       case ViewCanvasEventType.DELETE_NODE:
+        const deleteEvt = ViewEditorEvent.create(ViewEditorPart.CANVAS, ViewEditorEventType.DELETE_NODE, event.args);
+        this.editorService.editorEvent.emit(deleteEvt);
+        break;
       case ViewCanvasEventType.CANVAS_SELECTION_CHANGED:
 
         //
@@ -255,15 +270,15 @@ export class ViewCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     return [];
   }
-
-  /**
-   * Handle removal of View Source
-   * @param {SchemaNode} source the view source to be removed
-   */
-  public onViewSourceRemoved( source: SchemaNode ): void {
-    const cmd = CommandFactory.createRemoveSourcesCommand( [ source ] );
-    this.editorService.fireViewStateHasChanged( ViewEditorPart.CANVAS, cmd );
-  }
+  //
+  // /**
+  //  * Handle removal of View Source
+  //  * @param {SchemaNode} source the view source to be removed
+  //  */
+  // public onViewSourceRemoved( source: SchemaNode ): void {
+  //   const cmd = CommandFactory.createRemoveSourcesCommand( [ source ] );
+  //   this.editorService.fireViewStateHasChanged( ViewEditorPart.CANVAS, cmd );
+  // }
 
   /**
    * @returns {boolean} true if save view notification is to be shown


### PR DESCRIPTION
* Starts to implement the removal of a node through the view editor event
  system resulting in the deletion of the node rendered in the canvas

* add-source-command
 * Provides an optional id parameter to the constructor. If no id is
   provided then 1 is generated. This allows for identifers provided by
   komodo models to be passed in and used repeatedly.
 * Getting the id with a sourcePath will append the source path to the
   end of the identifier. If the command created more than 1 node due to
   multiple source paths then this should delineate the correct one.

* remove-sources-command
 * Implements support for removing source with specific identifiers rather
   then just source paths that may be duplicated

* CommandFactory
 * Implements handling of identifiers

* canvas-service
* view-canvas.component
* view-editor.component
 * Implements support for the deletion of a source