### PR TITLE
TEIIDTOOLS-479 Improve selectionService usage

### DIFF
--- a/src/main/ngapp/src/app/core/selection.service.ts
+++ b/src/main/ngapp/src/app/core/selection.service.ts
@@ -19,6 +19,7 @@ import { Injectable } from "@angular/core";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
 import { Connection } from "@connections/shared/connection.model";
 import { ViewDefinition } from "@dataservices/shared/view-definition.model";
+import { SqlView } from "@dataservices/shared/sql-view.model";
 
 @Injectable()
 export class SelectionService {
@@ -54,6 +55,27 @@ export class SelectionService {
    */
   public get hasSelectedVirtualization(): boolean {
     return this.selectedVirtualization && this.selectedVirtualization !== null;
+  }
+
+  /**
+   * Get the current Virtualization selection's views.View
+   * The ViewDefinition name is currently set to the full "modelName"."viewName" of the view.
+   * @returns {SqlView[]} the selected Dataservice view definitions
+   */
+  public getSelectedVirtualizationViewNames( ): SqlView[] {
+    if ( !this.hasSelectedVirtualization ) {
+      return [];
+    }
+
+    const modelName = this.selectedVirtualization.getServiceViewModel();
+    const serviceViews = this.selectedVirtualization.getServiceViewNames();
+
+    const allViewNames: SqlView[] = [];
+    for ( const serviceView of serviceViews ) {
+      allViewNames.push(new SqlView(modelName + "." + serviceView));
+    }
+
+    return allViewNames;
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/create-virtualization-dialog/create-virtualization-dialog.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/create-virtualization-dialog/create-virtualization-dialog.component.spec.ts
@@ -15,6 +15,7 @@ import { CreateVirtualizationDialogComponent } from "./create-virtualization-dia
 import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
+import { SelectionService } from "@core/selection.service";
 
 describe('CreateVirtualizationDialogComponent', () => {
   let component: CreateVirtualizationDialogComponent;
@@ -31,7 +32,7 @@ describe('CreateVirtualizationDialogComponent', () => {
         NotificationModule
       ],
       declarations: [ CreateVirtualizationDialogComponent ],
-      providers: [ AppSettingsService, BsModalRef, LoggerService, NotifierService,
+      providers: [ AppSettingsService, BsModalRef, LoggerService, NotifierService, SelectionService,
         { provide: DataserviceService, useClass: MockDataserviceService },
         { provide: VdbService, useClass: MockVdbService }
       ]

--- a/src/main/ngapp/src/app/dataservices/create-virtualization-dialog/create-virtualization-dialog.component.ts
+++ b/src/main/ngapp/src/app/dataservices/create-virtualization-dialog/create-virtualization-dialog.component.ts
@@ -25,6 +25,7 @@ import { AbstractControl, FormControl, FormGroup } from "@angular/forms";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { CreateVirtualizationResult } from "@dataservices/create-virtualization-dialog/create-virtualization-result.model";
+import { SelectionService } from "@core/selection.service";
 
 @Component({
   selector: "app-create-virtualization-dialog",
@@ -62,15 +63,17 @@ export class CreateVirtualizationDialogComponent implements OnInit {
 
   private loggerService: LoggerService;
   private dataserviceService: DataserviceService;
+  private selectionService: SelectionService;
   private vdbService: VdbService;
   private serviceVdbName = "";
 
   constructor(bsModalRef: BsModalRef, logger: LoggerService,
-              dataserviceService: DataserviceService, vdbService: VdbService) {
+              dataserviceService: DataserviceService, selectionService: SelectionService, vdbService: VdbService) {
     this.bsModalRef = bsModalRef;
     this.loggerService = logger;
     this.dataserviceService = dataserviceService;
-    const dService = this.dataserviceService.getSelectedDataservice();
+    this.selectionService = selectionService;
+    const dService = this.selectionService.getSelectedVirtualization();
     if ( dService && dService !== null ) {
       this.serviceVdbName = dService.getServiceVdbName();
     }

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -72,7 +72,7 @@
       <!-- The list or card view -->
       <div class="col-md-12" *ngIf="isLoaded('dataservices')">
         <div class="dataservices-toast">
-          <!-- Notification for Dataservice opertions -->
+          <!-- Toast Notification for Dataservice operations -->
           <pfng-toast-notification *ngIf="showToastNotification" [header]="toastNotificationHeader"
                                  [message]="toastNotificationMessage"
                                  [type]="toastNotificationType">

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.ts
@@ -452,8 +452,8 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
 
   public onTest(svcName: string): void {
     const selectedService =  this.filteredDataservices.find((x) => x.getId() === svcName);
-    this.dataserviceService.setSelectedDataservice(selectedService);
-    this.allSvcViewNames = this.dataserviceService.getSelectedDataserviceViewNames();
+    this.selectionService.setSelectedVirtualization(selectedService);
+    this.allSvcViewNames = this.selectionService.getSelectedVirtualizationViewNames();
     this.selectedSvcViewNames = [];
     this.selectedSvcViewNames.push(this.allServiceViewNames[0]);
 
@@ -661,7 +661,6 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
         (dataservices) => {
           for (const ds of dataservices) {
             if (ds.getId() === virtName) {
-              self.dataserviceService.setSelectedDataservice(ds);
               self.selectionService.setSelectedVirtualization(ds);
               self.createView(ds, viewDefn);
             }
@@ -678,7 +677,7 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
   }
 
   private createView(dataservice: Dataservice, viewDefn: ViewDefinition): void {
-    const selectedDs = this.dataserviceService.getSelectedDataservice();
+    const selectedDs = this.selectionService.getSelectedVirtualization();
     let editorId = "";
     if ( selectedDs || selectedDs !== null ) {
       editorId = this.getEditorStateId(selectedDs, viewDefn);
@@ -731,12 +730,9 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
    */
   public onEdit(svcName: string): void {
     const selectedService =  this.filteredDataservices.find((x) => x.getId() === svcName);
-    this.dataserviceService.setSelectedDataservice(selectedService);
+    this.selectionService.setSelectedVirtualization(selectedService);
 
     this.closeLookPanels();
-
-    // Sets the selected dataservice and edit mode before transferring
-    this.selectionService.setSelectedVirtualization(selectedService);
 
     const link: string[] = [ DataservicesConstants.viewPath ];
     this.logger.debug("[DataservicesPageComponent] Navigating to: %o", link);
@@ -750,8 +746,8 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
    */
   public onQuickLook(svcName: string): void {
     const selectedService =  this.filteredDataservices.find((x) => x.getId() === svcName);
-    this.dataserviceService.setSelectedDataservice(selectedService);
-    this.allSvcViewNames = this.dataserviceService.getSelectedDataserviceViewNames();
+    this.selectionService.setSelectedVirtualization(selectedService);
+    this.allSvcViewNames = this.selectionService.getSelectedVirtualizationViewNames();
     this.selectedSvcViewNames = [];
     this.selectedSvcViewNames.push(this.allServiceViewNames[0]);
     const viewName = this.selectedSvcViewNames[0];
@@ -776,7 +772,7 @@ export class DataservicesComponent extends AbstractPageComponent implements OnIn
    */
   public onOdataLook(svcName: string): void {
     const selectedService =  this.filteredDataservices.find((x) => x.getId() === svcName);
-    this.dataserviceService.setSelectedDataservice(selectedService);
+    this.selectionService.setSelectedVirtualization(selectedService);
 
     if (!this.odataEditorShowing) {
       this.setOdataEditorPanelOpenState(true);

--- a/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.ts
+++ b/src/main/ngapp/src/app/dataservices/odata-control/odata-control.component.ts
@@ -28,6 +28,7 @@ import { Odata } from "@dataservices/odata-control/odata.model";
 import { OdataEntity } from "@dataservices/odata-control/odata-entity.model";
 import { OdataColumn } from "@dataservices/odata-control/odata-column.model";
 import { OdataWhere } from "@dataservices/odata-control/odata-where.model";
+import { SelectionService } from "@core/selection.service";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -44,6 +45,7 @@ export class OdataControlComponent implements OnChanges {
   private dataserviceService: DataserviceService;
   private dataservice: Dataservice;
   private logger: LoggerService;
+  private selectionService: SelectionService;
   public i18n: OdataConstants = new OdataConstants();
 
   public searchMsg: string;
@@ -91,9 +93,11 @@ export class OdataControlComponent implements OnChanges {
   //
   public results: string = null;
 
-  constructor( dataserviceService: DataserviceService, logger: LoggerService ) {
+  constructor( dataserviceService: DataserviceService, logger: LoggerService,
+               selectionService: SelectionService ) {
     this.dataserviceService = dataserviceService;
     this.logger = logger;
+    this.selectionService = selectionService;
   }
 
   public get rootUrl(): string {
@@ -105,7 +109,7 @@ export class OdataControlComponent implements OnChanges {
   }
 
   public ngOnChanges(changes: SimpleChanges): void {
-    this.dataservice = this.dataserviceService.getSelectedDataservice();
+    this.dataservice = this.selectionService.getSelectedVirtualization();
 
     this.metadataFetchInProgress = false;
 

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.model.ts
@@ -105,10 +105,7 @@ export class Dataservice implements Identifiable< string > {
    * @returns {string} the dataservice Vdb name (can be null)
    */
   public getServiceVdbName(): string {
-    if (this.serviceVdbName && this.serviceVdbName !== null) {
-      return this.serviceVdbName;
-    }
-    return "";
+    return this.serviceVdbName;
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
@@ -41,8 +41,6 @@ import { Subject } from "rxjs/Subject";
 import { Subscription } from "rxjs/Subscription";
 import * as _ from "lodash";
 import * as vkbeautify from 'vkbeautify';
-import { ViewDefinition } from "@dataservices/shared/view-definition.model";
-import { SqlView } from "@dataservices/shared/sql-view.model";
 import { ViewEditorState } from "@dataservices/shared/view-editor-state.model";
 
 @Injectable()
@@ -60,8 +58,6 @@ export class DataserviceService extends ApiService {
   private notifierService: NotifierService;
   private appSettingsService: AppSettingsService;
   private vdbService: VdbService;
-  private selectedDataservice: Dataservice;
-  private dataserviceCurrentViewDefinition: ViewDefinition[] = [];
   private cachedDataserviceDeployStates: Map<string, DeploymentState> = new Map<string, DeploymentState>();
   private cachedDataserviceVirtualizations: Map<string, Virtualization> = new Map<string, Virtualization>();
   private updatesSubscription: Subscription;
@@ -91,92 +87,6 @@ export class DataserviceService extends ApiService {
     ds.setDescription(description);
 
     return ds;
-  }
-
-  /**
-   * Set the current Dataservice selection
-   * @param {Dataservice} service the Dataservice
-   */
-  public setSelectedDataservice(service: Dataservice): void {
-    this.selectedDataservice = service;
-    // When the dataservice is selected, init the selected view
-    const viewDefns: ViewDefinition[] = this.getSelectedDataserviceViews();
-    this.dataserviceCurrentViewDefinition = [];
-    if (viewDefns && viewDefns.length > 0) {
-      this.dataserviceCurrentViewDefinition.push(viewDefns[0]);
-    }
-  }
-
-  /**
-   * Get the current Dataservice selection
-   * @returns {Dataservice} the selected Dataservice
-   */
-  public getSelectedDataservice( ): Dataservice {
-    return this.selectedDataservice;
-  }
-
-  /**
-   * Get the current Dataservice selection's views.View
-   * The ViewDefinition name is currently set to the full "modelName"."viewName" of the view.
-   * @returns {ViewDefinition[]} the selected Dataservice view definitions
-   */
-  public getSelectedDataserviceViews( ): ViewDefinition[] {
-    if (!this.selectedDataservice || this.selectedDataservice === null) {
-      return [];
-    }
-
-    const modelName = this.selectedDataservice.getServiceViewModel();
-    const serviceViews = this.selectedDataservice.getServiceViewNames();
-
-    // build the views using the model and view names
-    const allViews: ViewDefinition[] = [];
-    for ( const serviceView of serviceViews ) {
-      const aView: ViewDefinition = new ViewDefinition();
-      aView.setName(modelName + "." + serviceView);
-
-      allViews.push(aView);
-    }
-
-    return allViews;
-  }
-
-  /**
-   * Get the current Dataservice selection's views.View
-   * The ViewDefinition name is currently set to the full "modelName"."viewName" of the view.
-   * @returns {ViewDefinition[]} the selected Dataservice view definitions
-   */
-  public getSelectedDataserviceViewNames( ): SqlView[] {
-    if (!this.selectedDataservice || this.selectedDataservice === null) {
-      return [];
-    }
-
-    const modelName = this.selectedDataservice.getServiceViewModel();
-    const serviceViews = this.selectedDataservice.getServiceViewNames();
-
-    const allViewNames: SqlView[] = [];
-    for ( const serviceView of serviceViews ) {
-      allViewNames.push(new SqlView(modelName + "." + serviceView));
-    }
-
-    return allViewNames;
-  }
-
-  /**
-   * Get the current Dataservice current view.  The table object is used for the view,
-   * with the View name set to the full "modelName"."viewName" of the view.
-   * @returns {ViewDefinition[]} the Dataservice current view definition
-   */
-  public getSelectedDataserviceCurrentView( ): ViewDefinition[] {
-    return this.dataserviceCurrentViewDefinition;
-  }
-
-  /**
-   * Set the current Dataservice current view.  The table object is used for the view,
-   * with the View name set to the full "modelName"."viewName" of the view.
-   * @param {ViewDefinition[]} view the current view
-   */
-  public setSelectedDataserviceCurrentView( view: ViewDefinition[] ): void {
-    this.dataserviceCurrentViewDefinition = view;
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -32,8 +32,6 @@ import "rxjs/add/operator/catch";
 import "rxjs/add/operator/map";
 import { Observable } from "rxjs/Observable";
 import { ErrorObservable } from "rxjs/observable/ErrorObservable";
-import { ViewDefinition } from "@dataservices/shared/view-definition.model";
-import { SqlView } from "@dataservices/shared/sql-view.model";
 import { ViewEditorState } from "@dataservices/shared/view-editor-state.model";
 
 @Injectable()
@@ -57,12 +55,6 @@ export class MockDataserviceService extends DataserviceService {
     this.queryResults = testDataService.getQueryResults();
 
     this.editorViewStateMap = testDataService.getViewEditorStateMap();
-
-    // set selected dataservice, so it's not empty
-    const ds = new Dataservice();
-    ds.setId("testDs");
-    ds.setServiceVdbName("testDsVdb");
-    this.setSelectedDataservice(ds);
   }
 
   /**
@@ -99,46 +91,6 @@ export class MockDataserviceService extends DataserviceService {
   public downloadDataservice( dataserviceName: string ): Observable< boolean > {
     alert( "Download of " + dataserviceName + " happens here" );
     return Observable.of( true );
-  }
-
-  /**
-   * Set the current Dataservice selection
-   * @param {Dataservice} service the Dataservice
-   */
-  public setSelectedDataservice(service: Dataservice): void {
-    this.selectedDs = service;
-  }
-
-  /**
-   * Get the current Dataservice selection
-   * @returns {Dataservice} the selected Dataservice
-   */
-  public getSelectedDataservice( ): Dataservice {
-    return this.selectedDs;
-  }
-
-  /**
-   * Get the view definitions for the selected Dataservice
-   * @returns {ViewDefinition[]} the view definitions
-   */
-  public getSelectedDataserviceViews(): ViewDefinition[] {
-    const table: ViewDefinition = new ViewDefinition();
-    table.setName("views.View1");
-    const tables: ViewDefinition[] = [];
-    tables.push(table);
-
-    return tables;
-  }
-
-  /**
-   * Get the views for the selected Dataservice
-   * @returns {SqlView[]} the views
-   */
-  public getSelectedDataserviceViewNames(): SqlView[] {
-    const views: SqlView[] = [];
-    views.push(new SqlView("views.View1"));
-
-    return views;
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.spec.ts
@@ -7,9 +7,9 @@ import { LoggerService } from "@core/logger.service";
 import { MockAppSettingsService } from "@core/mock-app-settings.service";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
-import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
+import { SelectionService } from "@core/selection.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { CodemirrorModule } from "ng2-codemirror";
 import {
@@ -25,6 +25,7 @@ import {
 } from "patternfly-ng";
 import { SqlControlComponent } from "./sql-control.component";
 import { SqlView } from "@dataservices/shared/sql-view.model";
+import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 
 describe("SqlControlComponent", () => {
   let component: SqlControlComponent;
@@ -51,6 +52,7 @@ describe("SqlControlComponent", () => {
         AppSettingsService,
         LoggerService,
         NotifierService,
+        SelectionService,
         { provide: AppSettingsService, useClass: MockAppSettingsService },
         { provide: DataserviceService, useClass: MockDataserviceService },
         { provide: VdbService, useClass: MockVdbService }
@@ -66,8 +68,10 @@ describe("SqlControlComponent", () => {
     const service = TestBed.get( DataserviceService );
     let dataservices: Dataservice[];
     service.getAllDataservices().subscribe( ( values ) => { dataservices = values; } );
+
+    const selService = TestBed.get( SelectionService );
     // noinspection JSUnusedAssignment
-    service.setSelectedDataservice( dataservices[ 0 ] );
+    selService.setSelectedVirtualization( dataservices[ 0 ] );
 
     fixture = TestBed.createComponent(SqlControlComponent);
     component = fixture.componentInstance;

--- a/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.ts
+++ b/src/main/ngapp/src/app/dataservices/sql-control/sql-control.component.ts
@@ -28,6 +28,7 @@ import "codemirror/addon/selection/active-line.js";
 import "codemirror/mode/sql/sql.js";
 import { NgxDataTableConfig, TableConfig } from "patternfly-ng";
 import { SqlView } from "@dataservices/shared/sql-view.model";
+import { SelectionService } from "@core/selection.service";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -62,15 +63,18 @@ export class SqlControlComponent implements OnInit {
 
   private dataserviceService: DataserviceService;
   private logger: LoggerService;
+  private selectionService: SelectionService;
   private showResults = false;
   private queryResultsLoading: LoadingState;
   private queryResults: QueryResults;
   private queryMap: Map<string, string> = new Map<string, string>();
   private previousViewName: string;
 
-  constructor( dataserviceService: DataserviceService, logger: LoggerService ) {
+  constructor( dataserviceService: DataserviceService, logger: LoggerService,
+               selectionService: SelectionService ) {
     this.dataserviceService = dataserviceService;
     this.logger = logger;
+    this.selectionService = selectionService;
   }
 
   public ngOnInit(): void {
@@ -138,7 +142,7 @@ export class SqlControlComponent implements OnInit {
    * Submit the currently entered SQL
    */
   public submitCurrentQuery( ): void {
-    this.submitQuery(this.queryText, this.dataserviceService.getSelectedDataservice().getId(), 15, 0);
+    this.submitQuery(this.queryText, this.selectionService.getSelectedVirtualization().getId(), 15, 0);
   }
 
   /*

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.spec.ts
@@ -23,6 +23,7 @@ import {
   SortModule,
   TableModule,
   WizardModule } from "patternfly-ng";
+import { SelectionService } from "@core/selection.service";
 
 describe("TestDataserviceComponent", () => {
   let component: TestDataserviceComponent;
@@ -47,7 +48,7 @@ describe("TestDataserviceComponent", () => {
       ],
       declarations: [ SqlControlComponent, TestDataserviceComponent ],
       providers: [
-        NotifierService,
+        NotifierService, SelectionService,
         { provide: AppSettingsService, useClass: MockAppSettingsService },
         { provide: DataserviceService, useClass: MockDataserviceService },
         { provide: VdbService, useClass: MockVdbService }
@@ -63,8 +64,10 @@ describe("TestDataserviceComponent", () => {
     const service = TestBed.get( DataserviceService );
     let dataservices: Dataservice[];
     service.getAllDataservices().subscribe( ( values ) => { dataservices = values; } );
+
+    const selService = TestBed.get( SelectionService );
     // noinspection JSUnusedAssignment
-    service.setSelectedDataservice( dataservices[ 0 ] );
+    selService.setSelectedVirtualization( dataservices[ 1 ] );
 
     fixture = TestBed.createComponent(TestDataserviceComponent);
     component = fixture.componentInstance;

--- a/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.ts
+++ b/src/main/ngapp/src/app/dataservices/test-dataservice/test-dataservice.component.ts
@@ -3,11 +3,11 @@ import { Router } from "@angular/router";
 import { ActivatedRoute } from "@angular/router";
 import { LoggerService } from "@core/logger.service";
 import { Dataservice } from "@dataservices/shared/dataservice.model";
-import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
 import { AbstractPageComponent } from "@shared/abstract-page.component";
 import { LoadingState } from "@shared/loading-state.enum";
 import { SqlView } from "@dataservices/shared/sql-view.model";
+import { SelectionService } from "@core/selection.service";
 
 @Component({
   selector: "app-test-dataservice",
@@ -21,20 +21,20 @@ export class TestDataserviceComponent extends AbstractPageComponent {
   public pageError: any = "";
 
   private dataservice: Dataservice;
-  private dataserviceService: DataserviceService;
+  private selectionService: SelectionService;
   private pageLoadingState: LoadingState = LoadingState.LOADED_VALID;
   private selectedSvcViewNames: SqlView[] = [];
   private allSvcViewNames: SqlView[] = [];
   private quickLookQueryText: string;
 
-  constructor( router: Router, route: ActivatedRoute, dataserviceService: DataserviceService, logger: LoggerService ) {
+  constructor( router: Router, route: ActivatedRoute, selectionService: SelectionService, logger: LoggerService ) {
     super(route, logger);
-    this.dataserviceService = dataserviceService;
+    this.selectionService = selectionService;
   }
 
   public loadAsyncPageData(): void {
-    this.dataservice = this.dataserviceService.getSelectedDataservice();
-    this.allSvcViewNames = this.dataserviceService.getSelectedDataserviceViewNames();
+    this.dataservice = this.selectionService.getSelectedVirtualization();
+    this.allSvcViewNames = this.selectionService.getSelectedVirtualizationViewNames();
     this.selectedSvcViewNames = [];
     this.selectedSvcViewNames.push(this.allSvcViewNames[0]);
     const viewName = this.selectedSvcViewNames[0];

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/create-view-dialog/create-view-dialog.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/create-view-dialog/create-view-dialog.component.spec.ts
@@ -8,13 +8,12 @@ import {
   NotificationModule
 } from "patternfly-ng";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { DataserviceService } from "@dataservices/shared/dataservice.service";
-import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { AppSettingsService } from "@core/app-settings.service";
 import { LoggerService } from "@core/logger.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
+import { SelectionService } from "@core/selection.service";
 
 describe('CreateViewDialogComponent', () => {
   let component: CreateViewDialogComponent;
@@ -31,8 +30,7 @@ describe('CreateViewDialogComponent', () => {
         NotificationModule
       ],
       declarations: [ CreateViewDialogComponent ],
-      providers: [ AppSettingsService, BsModalRef, LoggerService, NotifierService,
-        { provide: DataserviceService, useClass: MockDataserviceService },
+      providers: [ AppSettingsService, BsModalRef, LoggerService, NotifierService, SelectionService,
         { provide: VdbService, useClass: MockVdbService }
       ]
     })

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/create-view-dialog/create-view-dialog.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/create-view-dialog/create-view-dialog.component.ts
@@ -23,8 +23,8 @@ import { LoggerService } from "@core/logger.service";
 import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
 import { AbstractControl, FormControl, FormGroup } from "@angular/forms";
 import { VdbService } from "@dataservices/shared/vdb.service";
-import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { ViewDefinition } from "@dataservices/shared/view-definition.model";
+import { SelectionService } from "@core/selection.service";
 
 @Component({
   selector: "app-create-view-dialog",
@@ -60,16 +60,16 @@ export class CreateViewDialogComponent implements OnInit {
   public viewPropertyForm: FormGroup;
 
   private loggerService: LoggerService;
-  private dataserviceService: DataserviceService;
+  private selectionService: SelectionService;
   private vdbService: VdbService;
   private serviceVdbName = "";
 
   constructor(bsModalRef: BsModalRef, logger: LoggerService,
-              dataserviceService: DataserviceService, vdbService: VdbService) {
+              selectionService: SelectionService, vdbService: VdbService) {
     this.bsModalRef = bsModalRef;
     this.loggerService = logger;
-    this.dataserviceService = dataserviceService;
-    const dService = this.dataserviceService.getSelectedDataservice();
+    this.selectionService = selectionService;
+    const dService = this.selectionService.getSelectedVirtualization();
     if ( dService && dService !== null ) {
       this.serviceVdbName = dService.getServiceVdbName();
     }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/editor-views.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/editor-views.component.spec.ts
@@ -23,6 +23,7 @@ import {
   SortModule,
   TableModule,
   WizardModule } from "patternfly-ng";
+import { SelectionService } from "@core/selection.service";
 
 describe('EditorViewsComponent', () => {
   let component: EditorViewsComponent;
@@ -53,6 +54,7 @@ describe('EditorViewsComponent', () => {
         { provide: DataserviceService, useClass: MockDataserviceService },
         LoggerService,
         NotifierService,
+        SelectionService,
         { provide: VdbService, useClass: MockVdbService },
         ViewEditorService
       ]

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message-log.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message-log.component.spec.ts
@@ -20,6 +20,7 @@ import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
 import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
 import { MessageLogComponent } from '@dataservices/virtualization/view-editor/editor-views/message-log/message-log.component';
+import { SelectionService } from "@core/selection.service";
 
 describe('MessageLogComponent', () => {
   let component: MessageLogComponent;
@@ -45,6 +46,7 @@ describe('MessageLogComponent', () => {
         { provide: DataserviceService, useClass: MockDataserviceService },
         LoggerService,
         NotifierService,
+        SelectionService,
         { provide: VdbService, useClass: MockVdbService },
         ViewEditorService
       ]

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/view-preview/view-preview.component.spec.ts
@@ -21,6 +21,7 @@ import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.se
 import { VdbService } from "@dataservices/shared/vdb.service";
 import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
+import { SelectionService } from "@core/selection.service";
 
 describe("ViewPreviewComponent", () => {
   let component: ViewPreviewComponent;
@@ -47,6 +48,7 @@ describe("ViewPreviewComponent", () => {
         { provide: DataserviceService, useClass: MockDataserviceService },
         LoggerService,
         NotifierService,
+        SelectionService,
         { provide: VdbService, useClass: MockVdbService },
         ViewEditorService
       ]

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.spec.ts
@@ -24,6 +24,7 @@ import { ViewPropertyEditorsComponent } from "@dataservices/virtualization/view-
 import { TabsModule } from "ngx-bootstrap";
 import { GraphVisualComponent, LinkVisualComponent, NodeVisualComponent } from "@dataservices/virtualization/view-editor/view-canvas/visuals";
 import { CanvasService } from "@dataservices/virtualization/view-editor/view-canvas/canvas.service";
+import { SelectionService } from "@core/selection.service";
 
 describe('ViewCanvasComponent', () => {
   let component: ViewCanvasComponent;
@@ -57,6 +58,7 @@ describe('ViewCanvasComponent', () => {
         CanvasService,
         LoggerService,
         NotifierService,
+        SelectionService,
         { provide: VdbService, useClass: MockVdbService },
         ViewEditorService
       ]

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.spec.ts
@@ -15,6 +15,7 @@ import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.se
 import { TableModule } from "patternfly-ng";
 import { SelectionService } from "@core/selection.service";
 import { BsModalService } from "ngx-bootstrap";
+import { Dataservice } from "@dataservices/shared/dataservice.model";
 
 describe('ViewEditorHeaderComponent', () => {
   let component: ViewEditorHeaderComponent;
@@ -46,6 +47,14 @@ describe('ViewEditorHeaderComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ViewEditorHeaderComponent);
     component = fixture.componentInstance;
+
+    const selService = TestBed.get( SelectionService );
+    const ds: Dataservice = new Dataservice();
+    ds.setId("testDs");
+    ds.setServiceVdbName("testDsVdb");
+    // noinspection JSUnusedAssignment
+    selService.setSelectedVirtualization( ds );
+
     fixture.detectChanges();
   });
 

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
@@ -146,7 +146,7 @@ export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
    */
   private initViews( ): void {
     this.viewsLoadingState = LoadingState.LOADING;
-    this.selectedVirtualization = this.dataserviceService.getSelectedDataservice();
+    this.selectedVirtualization = this.selectionService.getSelectedVirtualization();
     if ( !this.selectedVirtualization || this.selectedVirtualization === null ) {
       this.tableRows = [];
     }
@@ -303,7 +303,7 @@ export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
   }
 
   private createNewView(viewDefn: ViewDefinition): void {
-    const selectedDs = this.dataserviceService.getSelectedDataservice();
+    const selectedDs = this.selectionService.getSelectedVirtualization();
     const editorId = this.getEditorStateId(selectedDs, viewDefn);
 
     // Create new editor state to save
@@ -367,7 +367,7 @@ export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
    */
   private doDeleteView(viewDefnName: string): void {
     const selectedViewDefn =  this.tableRows.find((x) => x.getName() === viewDefnName);
-    const selectedDs = this.dataserviceService.getSelectedDataservice();
+    const selectedDs = this.selectionService.getSelectedVirtualization();
     const vdbName = selectedDs.getServiceVdbName();
     const editorStateId = vdbName.toLowerCase() + "." + viewDefnName;
     const dataserviceName = selectedDs.getId();

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.spec.ts
@@ -9,6 +9,7 @@ import { NotifierService } from "@dataservices/shared/notifier.service";
 import { ViewEditorService } from '@dataservices/virtualization/view-editor/view-editor.service';
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { SelectionService } from "@core/selection.service";
 
 describe('ViewEditorService', () => {
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('ViewEditorService', () => {
         { provide: DataserviceService, useClass: MockDataserviceService },
         LoggerService,
         NotifierService,
+        SelectionService,
         { provide: VdbService, useClass: MockVdbService },
         ViewEditorService
       ]

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
@@ -41,6 +41,7 @@ import { RemoveCompositionCommand } from "@dataservices/virtualization/view-edit
 import { ViewDefinition } from "@dataservices/shared/view-definition.model";
 import { ViewEditorState } from "@dataservices/shared/view-editor-state.model";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { SelectionService } from "@core/selection.service";
 
 @Injectable()
 export class ViewEditorService {
@@ -65,6 +66,7 @@ export class ViewEditorService {
   private _shouldFireEvents = true;
   private _undoMgr: UndoManager;
   private readonly _dataserviceService: DataserviceService;
+  private readonly _selectionService: SelectionService;
   private readonly _vdbService: VdbService;
   private _warningMsgCount = 0;
   private _selection: string[] = [];
@@ -72,9 +74,11 @@ export class ViewEditorService {
 
   constructor( logger: LoggerService,
                dataserviceService: DataserviceService,
+               selectionService: SelectionService,
                vdbService: VdbService ) {
     this._logger = logger;
     this._dataserviceService = dataserviceService;
+    this._selectionService = selectionService;
     this._vdbService = vdbService;
     this._undoMgr = new UndoManager();
   }
@@ -424,7 +428,7 @@ export class ViewEditorService {
     editorState.setUndoables(this._undoMgr.toArray());
     editorState.setViewDefinition(this._editorView);
 
-    const dataserviceName = this._dataserviceService.getSelectedDataservice().getId();
+    const dataserviceName = this._selectionService.getSelectedVirtualization().getId();
 
     this._dataserviceService.saveViewEditorStateRefreshViews( editorState, dataserviceName ).subscribe( () => {
         // fire save editor state succeeded event

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.spec.ts
@@ -12,6 +12,7 @@ import { MockAppSettingsService } from "@core/mock-app-settings.service";
 import { NotifierService } from "@dataservices/shared/notifier.service";
 import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { SelectionService } from "@core/selection.service";
 
 describe('ViewPropertyEditorsComponent', () => {
   let component: ViewPropertyEditorsComponent;
@@ -29,6 +30,7 @@ describe('ViewPropertyEditorsComponent', () => {
         { provide: DataserviceService, useClass: MockDataserviceService },
         LoggerService,
         NotifierService,
+        SelectionService,
         { provide: VdbService, useClass: MockVdbService },
         ViewEditorService
       ]


### PR DESCRIPTION
Improve selectionService usage - (previously the dataserviceService was used for some of the selections).
- removes all selection functions from the dataservice service.  The selectionService is now used exclusively.
- components that previously used dataserviceService for selection now use selectionService
- fixed all affected unitTests 