### PR TITLE
TEIIDTOOLS-481 Improvements to virtualization activation

### DIFF
--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.html
@@ -10,29 +10,29 @@
                      (onActionSelect)="handleAction($event)">
         </pfng-action>
       </div>
-      <span class="pull-left fa fa-check-circle-o fa-2x card-action-icon"
+      <span class="pull-left fa fa-circle card-action-icon"
             style="color:green;"
             *ngIf="dataservice.serviceDeploymentActive"
             data-toggle="tooltip"
             data-placement="right"
             title="Active">
       </span>
-      <span class="pull-left fa fa-times-circle-o fa-2x card-action-icon"
+      <span class="pull-left fa fa-circle card-action-icon"
             style="color:red;"
             *ngIf="dataservice.serviceDeploymentFailed"
             data-toggle="tooltip"
             data-placement="right"
             title="Failed to activate">
       </span>
-      <span class="pull-left fa fa-exclamation-triangle fa-2x card-action-icon"
+      <span class="pull-left fa fa-circle card-action-icon"
             style="color:orange;"
             *ngIf="dataservice.serviceDeploymentInactive"
             data-toggle="tooltip"
             data-placement="right"
             title="Inactive">
       </span>
-      <span class="pull-left fa fa-times-circle-o fa-2x card-action-icon"
-            style="color:red;"
+      <span class="pull-left fa fa-circle card-action-icon"
+            style="color:grey;"
             *ngIf="dataservice.serviceDeploymentNotDeployed"
             data-toggle="tooltip"
             data-placement="right"

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
@@ -19,16 +19,20 @@
             </div>
             <div class="list-pf-content-wrapper">
               <div class="list-pf-main-content">
-                <span class="pull-left pficon-ok"
+                <span class="pull-left fa fa-circle"
+                      style="color:green"
                       *ngIf="item.serviceDeploymentActive">
                 </span>
-                <span class="pull-left pficon-error-circle-o"
+                <span class="pull-left fa fa-circle"
+                      style="color:red"
                       *ngIf="item.serviceDeploymentFailed">
                 </span>
-                <span class="pull-left pficon-warning-triangle-o"
+                <span class="pull-left fa fa-circle"
+                      style="color:orange"
                       *ngIf="item.serviceDeploymentInactive">
                 </span>
-                <span class="pull-left pficon-unknown"
+                <span class="pull-left fa fa-circle"
+                      style="color:grey"
                       *ngIf="item.serviceDeploymentNotDeployed">
                 </span>
                 <span class="pull-left fa fa-spinner fa-pulse"

--- a/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-vdb.service.ts
@@ -32,6 +32,8 @@ import "rxjs/add/observable/throw";
 import "rxjs/add/operator/catch";
 import "rxjs/add/operator/map";
 import { Observable } from "rxjs/Observable";
+import {environment} from "@environments/environment";
+import {VdbsConstants} from "@dataservices/shared/vdbs-constants";
 
 @Injectable()
 export class MockVdbService extends VdbService {
@@ -95,11 +97,29 @@ export class MockVdbService extends VdbService {
   }
 
   /**
+   * Determine if the workspace has a vdb with the supplied name
+   * @param {string} vdbName the name of the VDB
+   * @returns {Observable<boolean>}
+   */
+  public hasWorkspaceVdb(vdbName: string): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
    * Delete a vdb via the komodo rest interface
    * @param {string} vdbId
    * @returns {Observable<boolean>}
    */
   public deleteVdb(vdbId: string): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Delete a vdb if found via the komodo rest interface
+   * @param {string} vdbId
+   * @returns {Observable<boolean>}
+   */
+  public deleteVdbIfFound(vdbId: string): Observable<boolean> {
     return Observable.of(true);
   }
 

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
@@ -309,6 +309,8 @@ export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
       } else {
         this.createNewView(viewDefn);
       }
+      // addition of a view undeploys active serviceVdb
+      this.editorService.undeploySelectedVirtualization();
     });
   }
 
@@ -389,6 +391,8 @@ export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
       .subscribe(
         (wasSuccess) => {
           self.removeViewDefinitionFromList(selectedViewDefn);
+          // deletion of a view undeploys active serviceVdb
+          self.editorService.undeploySelectedVirtualization();
         },
         (error) => {
           self.logger.error("[VirtualizationComponent] Error deleting the editor state: %o", error);


### PR DESCRIPTION
Improvements to force the deployed virtualization to stay in sync after editing.
- The status indicator on the virtualization card and list was changed to a simple dot.  The dot changes colors based upon the state of the deployed virtualization
- Add a function in view-editor.service to undeploy the selected virtualization vdb.  When editing a virtualization, the vdb is undeployed whenever a view is added / removed / edited.
- added a couple functions in the mock-vdb-service.