### PR TITLE
TTOOLS-483 Add ability to update virtualization description

### DIFF
--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.css
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.css
@@ -89,3 +89,9 @@ a.list-pf-title.view-name {
 .views-details h1, .h1 {
   font-size: 14px;
 }
+
+.dataservice-card-edit-icon {
+  color: var(--card-action-icon-color);
+  cursor: pointer;
+  margin-left: 7px;
+}

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.html
@@ -149,6 +149,9 @@
       <a [routerLink]="[dataservice.getId()]" (click)="onClick(editEvent)">{{ dataservice.getId() }}</a>
     </div>
     <div class="row">
+      <div class="fa fa-edit pull-left dataservice-card-edit-icon" (click)="onClick(editDescriptionEvent)"></div>
+    </div>
+    <div class="row">
       <div class="object-card-description">{{ description }}</div>
     </div>
   </ng-template>

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservice-card/dataservice-card.component.ts
@@ -44,12 +44,14 @@ export class DataserviceCardComponent implements DoCheck, OnInit {
   public static readonly testDataserviceEvent = "test";
   public static readonly downloadDataserviceEvent = "download";
   public static readonly odataLookDataserviceEvent = "odataLook";
+  public static readonly editDescriptionDataserviceEvent = "editDescription";
 
   public readonly editEvent = DataserviceCardComponent.editDataserviceEvent;
   public readonly quickLookEvent = DataserviceCardComponent.quickLookDataserviceEvent;
   public readonly testEvent = DataserviceCardComponent.testDataserviceEvent;
   public readonly downloadEvent = DataserviceCardComponent.downloadDataserviceEvent;
   public readonly odataLookEvent = DataserviceCardComponent.odataLookDataserviceEvent;
+  public readonly editDescriptionEvent = DataserviceCardComponent.editDescriptionDataserviceEvent;
 
   @Input() public dataservice: Dataservice;
   @Input() public selectedDataservices: Dataservice[];

--- a/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-cards/dataservices-cards.component.ts
@@ -42,6 +42,7 @@ export class DataservicesCardsComponent {
   @Output() public quickLookDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public downloadDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public odataLookDataservice: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public editDescriptionDataservice: EventEmitter<string> = new EventEmitter<string>();
 
   public logger: LoggerService;
 
@@ -84,6 +85,9 @@ export class DataservicesCardsComponent {
         break;
       case DataserviceCardComponent.odataLookDataserviceEvent:
         this.odataLookDataservice.emit( event.dataserviceName );
+        break;
+      case DataserviceCardComponent.editDescriptionDataserviceEvent:
+        this.editDescriptionDataservice.emit( event.dataserviceName );
         break;
       default:
         this.logger.error( "Unhandled event type of '" + event.eventType + "'" );

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.html
@@ -97,7 +97,10 @@
                   </slide-in>
                 </div>
                 <a class="object-name-link" [routerLink]="[item.getId()]" (click)="onEditDataservice(item.getId())">{{ item.getId() }}</a>
-                <div class="list-pf-description">{{ getDescription( item ) }}</div>
+                <div class="list-pf-description">
+                  <span class="fa fa-edit pull-left dataservice-card-edit-icon" (click)="onEditDescription(item.getId())"></span>
+                  <span>{{ getDescription( item ) }}</span>
+                </div>
               </div>
               <div class="list-pf-additional-content">
                 <pfng-list-expand-toggle [expandId]="'views'" [item]="item" [template]="viewsTemplate">

--- a/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices-list/dataservices-list.component.ts
@@ -68,6 +68,7 @@ export class DataservicesListComponent implements OnInit {
   @Output() public editDataservice: EventEmitter<NameValue> = new EventEmitter<NameValue>();
   @Output() public quickLookDataservice: EventEmitter<string> = new EventEmitter<string>();
   @Output() public odataLookDataservice: EventEmitter<string> = new EventEmitter<string>();
+  @Output() public editDescriptionDataservice: EventEmitter<string> = new EventEmitter<string>();
 
   @ViewChild('publishLogsEditor') private logEditor: any;
 
@@ -250,6 +251,10 @@ export class DataservicesListComponent implements OnInit {
   public onEditDataservice(dataserviceName: string): void {
     const nameVal = new NameValue(dataserviceName, null);
     this.editDataservice.emit(nameVal);
+  }
+
+  public onEditDescription(dataserviceName: string): void {
+    this.editDescriptionDataservice.emit(dataserviceName);
   }
 
   public onEditView(dsNameView: NameValue): void {

--- a/src/main/ngapp/src/app/dataservices/dataservices.component.html
+++ b/src/main/ngapp/src/app/dataservices/dataservices.component.html
@@ -85,14 +85,16 @@
                                  (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
                                  (editDataservice)="onEdit($event)" (quickLookDataservice)="onQuickLook($event)"
                                  (downloadDataservice)="onDownload($event)" (odataLookDataservice)="onOdataLook($event)"
-                                 (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)">
+                                 (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"
+                                 (editDescriptionDataservice)="onEditDescription($event)">
           </app-dataservices-list>
           <app-dataservices-cards *ngIf="isCardLayout && hasDataservices" [dataservices]="filteredDataservices" [selectedDataservices]="selectedDataservices"
                                   (activateDataservice)="onActivate($event)" (testDataservice)="onTest($event)"
                                   (publishDataservice)="onPublish($event)" (deleteDataservice)="onDelete($event)"
                                   (editDataservice)="onEdit($event)" (quickLookDataservice)="onQuickLook($event)"
                                   (downloadDataservice)="onDownload($event)" (odataLookDataservice)="onOdataLook($event)"
-                                  (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)">
+                                  (dataserviceSelected)="onSelected($event)" (dataserviceDeselected)="onDeselected($event)"
+                                  (editDescriptionDataservice)="onEditDescription($event)">
           </app-dataservices-cards>
         </div>
       </div>

--- a/src/main/ngapp/src/app/dataservices/dataservices.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.module.ts
@@ -74,6 +74,7 @@ import { ViewPropertyEditorsComponent } from './virtualization/view-editor/view-
 import { AddCompositionWizardComponent } from './virtualization/view-editor/add-composition-wizard/add-composition-wizard.component';
 import { CreateViewDialogComponent } from './virtualization/view-editor/create-view-dialog/create-view-dialog.component';
 import { CreateViewsDialogComponent } from './create-views-dialog/create-views-dialog.component';
+import { SetDescriptionDialogComponent } from "@dataservices/set-description-dialog/set-description-dialog.component";
 
 @NgModule({
   imports: [
@@ -127,7 +128,8 @@ import { CreateViewsDialogComponent } from './create-views-dialog/create-views-d
     LinkVisualComponent,
     AddCompositionWizardComponent,
     CreateViewDialogComponent,
-    CreateViewsDialogComponent
+    CreateViewsDialogComponent,
+    SetDescriptionDialogComponent
   ],
   providers: [
     {
@@ -150,7 +152,7 @@ import { CreateViewsDialogComponent } from './create-views-dialog/create-views-d
   exports: [
   ],
   entryComponents: [AddCompositionWizardComponent, ConfirmDialogComponent, ConnectionTableDialogComponent,
-                    CreateViewDialogComponent, CreateViewsDialogComponent, ProgressDialogComponent]
+                    CreateViewDialogComponent, CreateViewsDialogComponent, ProgressDialogComponent, SetDescriptionDialogComponent]
 })
 export class DataservicesModule { }
 

--- a/src/main/ngapp/src/app/dataservices/set-description-dialog/set-description-dialog.component.html
+++ b/src/main/ngapp/src/app/dataservices/set-description-dialog/set-description-dialog.component.html
@@ -1,0 +1,22 @@
+<div class="modal-header">
+  <h4 class="modal-title pull-left">{{ title }}</h4>
+  <button type="button" class="close pull-right" aria-label="Close" (click)="bsModalRef.hide()">
+    <span class="pficon pficon-close"></span>
+  </button>
+</div>
+<div class="modal-body">
+  <strong>{{message}}</strong><br>
+  <!-- Form for Description -->
+  <form [formGroup]="viewPropertyForm" class="form-horizontal">
+    <div [ngClass]="'form-group'">
+      <label class="col-sm-3 control-label">Description</label>
+      <div class="col-sm-8">
+        <textarea class="form-control" rows="4" maxlength="256" formControlName="description" title=""></textarea>
+      </div>
+    </div>
+  </form>
+</div>
+<div class="modal-footer">
+  <button i18n="@@setDescriptonDialog.cancel" type="button" class="btn btn-default" (click)="onCancelSelected()">{{ cancelButtonText }}</button>
+  <button i18n="@@setDescriptionDialog.delete" type="button" class="btn btn-primary" (click)="onOkSelected()" [disabled]="!okButtonEnabled">{{ okButtonText }}</button>
+</div>

--- a/src/main/ngapp/src/app/dataservices/set-description-dialog/set-description-dialog.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/set-description-dialog/set-description-dialog.component.spec.ts
@@ -1,0 +1,42 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SetDescriptionDialogComponent } from './set-description-dialog.component';
+import { HttpModule } from "@angular/http";
+import { BsModalRef, ModalModule } from "ngx-bootstrap";
+import {
+  ActionModule
+} from "patternfly-ng";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { AppSettingsService } from "@core/app-settings.service";
+import { LoggerService } from "@core/logger.service";
+
+describe('SetDescriptionDialogComponent', () => {
+  let component: SetDescriptionDialogComponent;
+  let fixture: ComponentFixture<SetDescriptionDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpModule,
+        FormsModule,
+        ReactiveFormsModule,
+        ModalModule.forRoot(),
+        ActionModule
+      ],
+      declarations: [ SetDescriptionDialogComponent ],
+      providers: [ AppSettingsService, BsModalRef, LoggerService
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SetDescriptionDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/ngapp/src/app/dataservices/set-description-dialog/set-description-dialog.component.ts
+++ b/src/main/ngapp/src/app/dataservices/set-description-dialog/set-description-dialog.component.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnInit } from "@angular/core";
+import { Output } from "@angular/core";
+import { EventEmitter } from "@angular/core";
+import { BsModalRef } from "ngx-bootstrap";
+import { LoggerService } from "@core/logger.service";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
+import { FormControl, FormGroup } from "@angular/forms";
+
+@Component({
+  selector: "app-create-view-dialog",
+  templateUrl: "./set-description-dialog.component.html",
+  styleUrls: ["./set-description-dialog.component.css"]
+})
+/**
+ * SetDescription Dialog.  Invoke this from another component as follows:
+ *
+ *     this.modalRef = this.modalService.show(SetDescriptionDialogComponent, {initialState});
+ *     this.modalRef.content.okAction.take(1).subscribe((description) => {
+ *       // do something with description
+ *     });
+ *
+ *     The expected initial state is as follows:
+ *     const initialState = {
+ *       title: "The dialog title",
+ *       cancelButtonText: "Text for cancel button",
+ *       confirmButtonText: "Text for confirm button"
+ *     };
+ */
+export class SetDescriptionDialogComponent implements OnInit {
+
+  @Output() public okAction: EventEmitter<string> = new EventEmitter<string>();
+
+  public readonly title = ViewEditorI18n.setDescriptionDialogTitle;
+  public readonly message = ViewEditorI18n.setDescriptionDialogMessage;
+  public readonly cancelButtonText = ViewEditorI18n.cancelButtonText;
+  public readonly okButtonText = ViewEditorI18n.okButtonText;
+  public description = "";
+  public okButtonEnabled = true;
+  public bsModalRef: BsModalRef;
+  public viewPropertyForm: FormGroup;
+
+  private loggerService: LoggerService;
+  private originalDescription = "";
+
+  constructor(bsModalRef: BsModalRef, logger: LoggerService) {
+    this.bsModalRef = bsModalRef;
+    this.loggerService = logger;
+    this.createViewPropertyForm();
+  }
+
+  public ngOnInit(): void {
+    this.originalDescription = this.description;
+    this.viewPropertyForm.controls["description"].setValue(this.description);
+  }
+
+  /*
+   * Creates the view property form
+   */
+  private createViewPropertyForm(): void {
+      this.viewPropertyForm = new FormGroup({
+        description: new FormControl(this.description)
+      });
+  }
+
+  /**
+   * OK selected.  Emit ViewDefinition with the view, then modal is closed
+   */
+  public onOkSelected(): void {
+    const theDescr = this.viewPropertyForm.controls["description"].value;
+
+    this.okAction.emit(theDescr);
+    this.bsModalRef.hide();
+  }
+
+  /**
+   * Cancel selected.  The modal is closed.
+   */
+  public onCancelSelected(): void {
+    this.bsModalRef.hide();
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/dataservice.service.ts
@@ -143,6 +143,21 @@ export class DataserviceService extends ApiService {
   }
 
   /**
+   * Update a dataservice via the komodo rest interface
+   * @param {NewDataservice} dataservice
+   * @returns {Observable<boolean>}
+   */
+  public updateDataservice(dataservice: NewDataservice): Observable<boolean> {
+    return this.http
+      .put(environment.komodoWorkspaceUrl + DataservicesConstants.dataservicesRestPath + "/" + dataservice.getId(),
+        dataservice, this.getAuthRequestOptions())
+      .map((response) => {
+        return response.ok;
+      })
+      .catch( ( error ) => this.handleError( error ) );
+  }
+
+  /**
    * Deploy a dataservice via the komodo rest interface
    * @param {string} dataserviceName
    * @returns {Observable<boolean>}

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -33,6 +33,8 @@ import "rxjs/add/operator/map";
 import { Observable } from "rxjs/Observable";
 import { ErrorObservable } from "rxjs/observable/ErrorObservable";
 import { ViewEditorState } from "@dataservices/shared/view-editor-state.model";
+import { environment } from "@environments/environment";
+import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
 
 @Injectable()
 export class MockDataserviceService extends DataserviceService {
@@ -75,6 +77,15 @@ export class MockDataserviceService extends DataserviceService {
     ds.setDescription( dataservice.getDescription() );
 
     this.services.push( ds );
+    return Observable.of(true);
+  }
+
+  /**
+   * Update a dataservice via the komodo rest interface
+   * @param {NewDataservice} dataservice
+   * @returns {Observable<boolean>}
+   */
+  public updateDataservice(dataservice: NewDataservice): Observable<boolean> {
     return Observable.of(true);
   }
 

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-i18n.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-i18n.ts
@@ -48,6 +48,10 @@ export class ViewEditorI18n {
   public static readonly createViewDialogMessage = "Enter name and description(optional) for the new view";
   public static readonly createViewDialogTitle = "Create View";
 
+  // set description dialog
+  public static readonly setDescriptionDialogTitle = "Set Virtualization Description";
+  public static readonly setDescriptionDialogMessage = "Set the description for this virtualization";
+
   // Add Composition Wizard
   public static readonly addCompositionWizardTitle = "Add Composition";
   public static readonly addCompositionWizardSelectSourceMessage = "Expand connection and select a source for the composition";

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
@@ -61,7 +61,7 @@ export class ViewEditorService {
   private readonly _logger: LoggerService;
   private _messages: Message[] = [];
   private _previewResults: QueryResults;
-  private _previewSql = null;
+  private _previewSql = "";
   private _readOnly = false;
   private _shouldFireEvents = true;
   private _undoMgr: UndoManager;
@@ -275,7 +275,7 @@ export class ViewEditorService {
   }
 
   /**
-   * @returns {string} the preview sql or '<not defined>' if not set
+   * @returns {string} the preview sql
    */
   public getPreviewSql(): string {
     return this._previewSql;
@@ -530,6 +530,9 @@ export class ViewEditorService {
     // Clear preview results
     this.setPreviewResults(null, null, ViewEditorPart.EDITOR);
 
+    if ( !this._editorView || this._editorView === null ) {
+      return;
+    }
     let querySql = "";
     if ( sourcePath != null && !sourcePath.startsWith(AddCompositionCommand.id) ) {
       // Fetch new results for source table


### PR DESCRIPTION
Adds capability for user to change a virtualization's description after the virtualization has been created.
- Added edit icon next to the description on the virtualization card and list.  Clicking on the icon will reveal a dialog for reset of the description
- Added dialog for display of the virtualization current description, allowing user to change it.
- Changing the description updates the repo object description via the rest interface.