### PR TITLE
TTOOLS-465 Addition of projected columns editor

### DIFF
--- a/src/main/ngapp/src/app/dataservices/create-views-dialog/create-views-dialog.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/create-views-dialog/create-views-dialog.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { CreateViewsDialogComponent } from "./create-views-dialog.component";
-import { ConnectionTreeSelectorComponent } from "@dataservices/virtualization/view-editor/connection-table-dialog/connection-tree-selector/connection-tree-selector.component";
 import { HttpModule } from "@angular/http";
 import {
   ActionModule,

--- a/src/main/ngapp/src/app/dataservices/create-views-dialog/create-views-dialog.component.ts
+++ b/src/main/ngapp/src/app/dataservices/create-views-dialog/create-views-dialog.component.ts
@@ -10,7 +10,6 @@ import {
   EmptyStateConfig,
   ListConfig,
   ListEvent,
-  NgxDataTableConfig,
   NotificationType,
   TableConfig
 } from "patternfly-ng";

--- a/src/main/ngapp/src/app/dataservices/dataservices.module.ts
+++ b/src/main/ngapp/src/app/dataservices/dataservices.module.ts
@@ -76,6 +76,7 @@ import { CreateViewDialogComponent } from './virtualization/view-editor/create-v
 import { CreateViewsDialogComponent } from './create-views-dialog/create-views-dialog.component';
 import { SetDescriptionDialogComponent } from "@dataservices/set-description-dialog/set-description-dialog.component";
 import { PropertyEditorComponent } from './virtualization/view-editor/view-property-editors/property-editor/property-editor.component';
+import { ProjectedColumnsEditorComponent } from './virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component';
 
 @NgModule({
   imports: [
@@ -131,7 +132,8 @@ import { PropertyEditorComponent } from './virtualization/view-editor/view-prope
     CreateViewDialogComponent,
     CreateViewsDialogComponent,
     SetDescriptionDialogComponent,
-    PropertyEditorComponent
+    PropertyEditorComponent,
+    ProjectedColumnsEditorComponent
   ],
   providers: [
     {

--- a/src/main/ngapp/src/app/dataservices/shared/composition.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/composition.model.ts
@@ -93,20 +93,14 @@ export class Composition {
    * @return {boolean} 'true' if initial source is set and on the left
    */
   public get initialSourceOnLeft(): boolean {
-    if (this.initialSourcePath !== null && this.leftSourcePath !== null && this.initialSourcePath === this.leftSourcePath) {
-      return true;
-    }
-    return false;
+    return this.initialSourcePath !== null && this.leftSourcePath !== null && this.initialSourcePath === this.leftSourcePath;
   }
 
   /**
    * @return {boolean} 'true' if initial source is set and on the right
    */
   public get initialSourceOnRight(): boolean {
-    if (this.initialSourcePath !== null && this.rightSourcePath !== null && this.initialSourcePath === this.rightSourcePath) {
-      return true;
-    }
-    return false;
+    return this.initialSourcePath !== null && this.rightSourcePath !== null && this.initialSourcePath === this.rightSourcePath;
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/mock-dataservice.service.ts
@@ -33,8 +33,6 @@ import "rxjs/add/operator/map";
 import { Observable } from "rxjs/Observable";
 import { ErrorObservable } from "rxjs/observable/ErrorObservable";
 import { ViewEditorState } from "@dataservices/shared/view-editor-state.model";
-import { environment } from "@environments/environment";
-import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
 
 @Injectable()
 export class MockDataserviceService extends DataserviceService {
@@ -151,10 +149,10 @@ export class MockDataserviceService extends DataserviceService {
   }
 
   /**
-   * @param {ViewEditorState} editorState the view editor state
+   * @param {ViewEditorState[]} editorStates the view editor state array
    * @returns {Observable<boolean>} `true` if the editor state was successfully saved
    */
-  public saveViewEditorState( editorState: ViewEditorState ): Observable< boolean > {
+  public saveViewEditorStates( editorStates: ViewEditorState[] ): Observable< boolean > {
     return Observable.of(true);
   }
 
@@ -199,11 +197,11 @@ export class MockDataserviceService extends DataserviceService {
   }
 
   /**
-   * @param {ViewEditorState} editorState the view editor state
+   * @param {ViewEditorState[]} editorStates the view editor state array
    * @param {string} dataserviceName the name of the dataservice
    * @returns {Observable<boolean>} `true` if the editor state was successfully saved
    */
-  public saveViewEditorStateRefreshViews( editorState: ViewEditorState, dataserviceName: string ): Observable< boolean > {
+  public saveViewEditorStatesRefreshViews( editorStates: ViewEditorState[], dataserviceName: string ): Observable< boolean > {
     return Observable.of(true);
   }
 

--- a/src/main/ngapp/src/app/dataservices/shared/projected-column.model.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/projected-column.model.spec.ts
@@ -1,0 +1,38 @@
+import { ProjectedColumn } from "@dataservices/shared/projected-column.model";
+
+describe("ProjectedColumn", () => {
+  let projCol1: ProjectedColumn;
+  let projCol2: ProjectedColumn;
+
+  beforeEach(() => {
+    projCol1 = null;
+    projCol2 = null;
+  });
+
+  it("should create", () => {
+    console.log("========== [ProjectedColumn] should create");
+    projCol1 = ProjectedColumn.create(
+      {
+        "name": "colName1",
+        "type": "string",
+        "selected": true
+      }
+    );
+    projCol2 = ProjectedColumn.create(
+      {
+        "name": "colName2",
+        "type": "integer",
+        "selected": false
+      }
+    );
+
+    expect(projCol1.getName()).toEqual("colName1");
+    expect(projCol1.getType()).toEqual("string");
+    expect(projCol1.selected).toEqual(true);
+
+    expect(projCol2.getName()).toEqual("colName2");
+    expect(projCol2.getType()).toEqual("integer");
+    expect(projCol2.selected).toEqual(false);
+  });
+
+});

--- a/src/main/ngapp/src/app/dataservices/shared/projected-column.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/projected-column.model.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ProjectedColumn model - to hold the column info for projected view columns
+ */
+export class ProjectedColumn {
+
+  private name: string;
+  private type: string;
+  public selected = false;
+
+  /**
+   * @param {Object} json the JSON representation of ProjectedColumn
+   * @returns {ProjectedColumn} the new ProjectedColumn (never null)
+   */
+  public static create( json: object = {} ): ProjectedColumn {
+    const projCol = new ProjectedColumn();
+    for (const field of Object.keys(json)) {
+      if (field === "name") {
+        projCol.setName(json[field]);
+      } else if (field === "type") {
+        projCol.setType(json[field]);
+      } else if (field === "selected") {
+        projCol.selected = json[field];
+      }
+    }
+    return projCol;
+  }
+
+  constructor() {
+    // nothing to do
+  }
+
+  /**
+   * @returns {string} the column name
+   */
+  public getName(): string {
+    return this.name;
+  }
+
+  /**
+   * @param {string} name the column name
+   */
+  public setName( name?: string ): void {
+    this.name = name ? name : null;
+  }
+
+  /**
+   * @returns {string} the column type
+   */
+  public getType(): string {
+    return this.type;
+  }
+
+  /**
+   * @param {string} type the column type
+   */
+  public setType( type?: string ): void {
+    this.type = type ? type : "";
+  }
+
+  /**
+   * Determine if the supplied ProjectedColumn is equal to this
+   * @param {ProjectedColumn} otherCol the other column
+   */
+  public isEqual( otherCol: ProjectedColumn ): boolean {
+    let equal = false;
+    if (this.getName() === otherCol.getName() &&
+        this.getType() === otherCol.getType() &&
+        this.selected === otherCol.selected ) {
+      equal = true;
+    }
+    return equal;
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/shared/view-definition.model.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/view-definition.model.spec.ts
@@ -3,53 +3,136 @@ import { CompositionOperator } from "@dataservices/shared/composition-operator.e
 import { CompositionType } from "@dataservices/shared/composition-type.enum";
 
 describe("ViewDefinition", () => {
-  let viewDefn: ViewDefinition;
+  let viewDefn1: ViewDefinition;
+  let viewDefn2: ViewDefinition;
 
   beforeEach(() => {
-    viewDefn = null;
+    viewDefn1 = null;
+    viewDefn2 = null;
   });
 
   it("should create", () => {
     console.log("========== [ViewDefinition] should create");
-    viewDefn = ViewDefinition.create(
+    viewDefn1 = ViewDefinition.create(
       {
         "viewName": "viewDefnName",
         "keng__description": "viewDescription",
         "isComplete": true,
         "sourcePaths":
           [
-            "sourcePath1",
-            "sourcePath2"
+            "connection=pgConn/schema=public/table=account",
+            "connection=pgConn/schema=public/table=holdings"
           ],
         "compositions":
           [
             {
               "name": "compositionName",
-              "leftSourcePath": "sourcePath1",
-              "rightSourcePath": "sourcePath2",
+              "leftSourcePath": "connection=pgConn/schema=public/table=account",
+              "rightSourcePath": "connection=pgConn/schema=public/table=holdings",
               "leftCriteriaColumn": "leftCriteriaCol",
               "rightCriteriaColumn": "rightCriteriaCol",
               "type": "INNER_JOIN",
               "operator": "EQ"
             }
-          ]
+          ],
+        "projectedColumns": [
+          {
+            "name": "ALL",
+            "type": "ALL",
+            "selected": true
+          }
+        ]
       }
     );
 
-    expect(viewDefn.getName()).toEqual("viewDefnName");
-    expect(viewDefn.getDescription()).toEqual("viewDescription");
-    expect(viewDefn.complete).toEqual(true);
-    expect(viewDefn.getSourcePaths().length).toEqual(2);
-    expect(viewDefn.getSourcePaths()[0]).toEqual("sourcePath1");
-    expect(viewDefn.getSourcePaths()[1]).toEqual("sourcePath2");
-    expect(viewDefn.getCompositions().length).toEqual(1);
-    expect(viewDefn.getCompositions()[0].getName()).toEqual("compositionName");
-    expect(viewDefn.getCompositions()[0].getLeftSourcePath()).toEqual("sourcePath1");
-    expect(viewDefn.getCompositions()[0].getRightSourcePath()).toEqual("sourcePath2");
-    expect(viewDefn.getCompositions()[0].getLeftCriteriaColumn()).toEqual("leftCriteriaCol");
-    expect(viewDefn.getCompositions()[0].getRightCriteriaColumn()).toEqual("rightCriteriaCol");
-    expect(viewDefn.getCompositions()[0].getType()).toEqual(CompositionType.INNER_JOIN);
-    expect(viewDefn.getCompositions()[0].getOperator()).toEqual(CompositionOperator.EQ);
+    viewDefn2 = ViewDefinition.create(
+      {
+        "viewName": "viewDefnName",
+        "keng__description": "viewDescription",
+        "isComplete": true,
+        "sourcePaths":
+          [
+            "connection=pgConn/schema=public/table=account",
+            "connection=pgConn/schema=public/table=holdings"
+          ],
+        "compositions":
+          [
+            {
+              "name": "compositionName",
+              "leftSourcePath": "connection=pgConn/schema=public/table=account",
+              "rightSourcePath": "connection=pgConn/schema=public/table=holdings",
+              "leftCriteriaColumn": "leftCriteriaCol",
+              "rightCriteriaColumn": "rightCriteriaCol",
+              "type": "INNER_JOIN",
+              "operator": "EQ"
+            }
+          ],
+        "projectedColumns": [
+          {
+            "name": "col1",
+            "type": "string",
+            "selected": true
+          },
+          {
+            "name": "col2",
+            "type": "integer",
+            "selected": false
+          },
+          {
+            "name": "col3",
+            "type": "string",
+            "selected": true
+          }
+        ]
+      }
+    );
+
+    expect(viewDefn1.getName()).toEqual("viewDefnName");
+    expect(viewDefn1.getDescription()).toEqual("viewDescription");
+    expect(viewDefn1.complete).toEqual(true);
+    expect(viewDefn1.getSourcePaths().length).toEqual(2);
+    expect(viewDefn1.getSourcePaths()[0]).toEqual("connection=pgConn/schema=public/table=account");
+    expect(viewDefn1.getSourcePaths()[1]).toEqual("connection=pgConn/schema=public/table=holdings");
+    expect(viewDefn1.getCompositions().length).toEqual(1);
+    expect(viewDefn1.getCompositions()[0].getName()).toEqual("compositionName");
+    expect(viewDefn1.getCompositions()[0].getLeftSourcePath()).toEqual("connection=pgConn/schema=public/table=account");
+    expect(viewDefn1.getCompositions()[0].getRightSourcePath()).toEqual("connection=pgConn/schema=public/table=holdings");
+    expect(viewDefn1.getCompositions()[0].getLeftCriteriaColumn()).toEqual("leftCriteriaCol");
+    expect(viewDefn1.getCompositions()[0].getRightCriteriaColumn()).toEqual("rightCriteriaCol");
+    expect(viewDefn1.getCompositions()[0].getType()).toEqual(CompositionType.INNER_JOIN);
+    expect(viewDefn1.getCompositions()[0].getOperator()).toEqual(CompositionOperator.EQ);
+    expect(viewDefn1.getProjectedColumns().length).toEqual(1);
+    expect(viewDefn1.getProjectedColumns()[0].getName()).toEqual("ALL");
+    expect(viewDefn1.getProjectedColumns()[0].getType()).toEqual("ALL");
+    expect(viewDefn1.getProjectedColumns()[0].selected).toEqual(true);
+    expect(viewDefn1.getPreviewSql()).toEqual("SELECT * FROM pgconnschemamodel.account AS A INNER JOIN pgconnschemamodel.holdings AS B ON A.leftCriteriaCol = B.rightCriteriaCol;");
+
+    expect(viewDefn2.getName()).toEqual("viewDefnName");
+    expect(viewDefn2.getDescription()).toEqual("viewDescription");
+    expect(viewDefn2.complete).toEqual(true);
+    expect(viewDefn2.getSourcePaths().length).toEqual(2);
+    expect(viewDefn2.getSourcePaths()[0]).toEqual("connection=pgConn/schema=public/table=account");
+    expect(viewDefn2.getSourcePaths()[1]).toEqual("connection=pgConn/schema=public/table=holdings");
+    expect(viewDefn2.getCompositions().length).toEqual(1);
+    expect(viewDefn2.getCompositions()[0].getName()).toEqual("compositionName");
+    expect(viewDefn2.getCompositions()[0].getLeftSourcePath()).toEqual("connection=pgConn/schema=public/table=account");
+    expect(viewDefn2.getCompositions()[0].getRightSourcePath()).toEqual("connection=pgConn/schema=public/table=holdings");
+    expect(viewDefn2.getCompositions()[0].getLeftCriteriaColumn()).toEqual("leftCriteriaCol");
+    expect(viewDefn2.getCompositions()[0].getRightCriteriaColumn()).toEqual("rightCriteriaCol");
+    expect(viewDefn2.getCompositions()[0].getType()).toEqual(CompositionType.INNER_JOIN);
+    expect(viewDefn2.getCompositions()[0].getOperator()).toEqual(CompositionOperator.EQ);
+    expect(viewDefn2.getProjectedColumns().length).toEqual(3);
+    expect(viewDefn2.getProjectedColumns()[0].getName()).toEqual("col1");
+    expect(viewDefn2.getProjectedColumns()[0].getType()).toEqual("string");
+    expect(viewDefn2.getProjectedColumns()[0].selected).toEqual(true);
+    expect(viewDefn2.getProjectedColumns()[1].getName()).toEqual("col2");
+    expect(viewDefn2.getProjectedColumns()[1].getType()).toEqual("integer");
+    expect(viewDefn2.getProjectedColumns()[1].selected).toEqual(false);
+    expect(viewDefn2.getProjectedColumns()[2].getName()).toEqual("col3");
+    expect(viewDefn2.getProjectedColumns()[2].getType()).toEqual("string");
+    expect(viewDefn2.getProjectedColumns()[2].selected).toEqual(true);
+    expect(viewDefn2.getPreviewSql()).toEqual("SELECT col1, col3 FROM pgconnschemamodel.account AS A INNER JOIN pgconnschemamodel.holdings AS B ON A.leftCriteriaCol = B.rightCriteriaCol;");
+
   });
 
 });

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/command-type.enum.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/command-type.enum.ts
@@ -53,6 +53,11 @@ export enum CommandType {
   /**
    * Command id for Add Composition
    */
-  UPDATE_VIEW_NAME_COMMAND = "UpdateViewNameCommand"
+  UPDATE_VIEW_NAME_COMMAND = "UpdateViewNameCommand",
+
+  /**
+   * Command id for Update Projected Columns
+   */
+  UPDATE_PROJECTED_COLUMNS_COMMAND = "UpdateProjectedColumnsCommand"
 
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/update-projected-columns-command.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/command/update-projected-columns-command.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
+import { Command } from "@dataservices/virtualization/view-editor/command/command";
+import { CommandType } from "@dataservices/virtualization/view-editor/command/command-type.enum";
+import { ProjectedColumn } from "@dataservices/shared/projected-column.model";
+
+export class UpdateProjectedColumnsCommand extends Command {
+
+  /**
+   * The command identifier.
+   *
+   * @type {string}
+   */
+  public static readonly id = CommandType.UPDATE_PROJECTED_COLUMNS_COMMAND;
+
+  /**
+   * The name of the command argument whose value is the new projected columns of the view.
+   *
+   * @type {string}
+   */
+  public static readonly newProjectedColumns = "newProjectedColumns";
+
+  /**
+   * The name of the command argument whose value is the replaced projected columns of the view.
+   *
+   * @type {string}
+   */
+  public static readonly oldProjectedColumns = "oldProjectedColumns";
+
+  /**
+   * Constructor
+   * the specified ProjectedColumns must be a ProjectedColumns object -OR- stringified projected columns
+   * @param {string | ProjectedColumn[]} newProjectedColumns the new projected columns or stringified projected columns
+   *                                   (cannot be `null` or empty)
+   * @param {string | ProjectedColumn[]} oldProjectedColumns the projected columns being replaced or stringified columns
+   *                                   (cannot be `null` or empty)
+   * @param {string} id the command id.  If not supplied, an id is generated.
+   */
+  public constructor( newProjectedColumns: string | ProjectedColumn[],
+                      oldProjectedColumns: string | ProjectedColumn[], id?: string) {
+    super( UpdateProjectedColumnsCommand.id, ViewEditorI18n.updateProjectedColumnsCommandName );
+
+    let newColsArg: string;
+    if ( typeof newProjectedColumns === 'string' ) {
+      newColsArg = newProjectedColumns as string;
+    } else {
+      newColsArg = JSON.stringify(newProjectedColumns);
+    }
+    this._args.set( UpdateProjectedColumnsCommand.newProjectedColumns, newColsArg );
+
+    let oldColsArg: string;
+    if ( typeof oldProjectedColumns === 'string' ) {
+      oldColsArg = oldProjectedColumns as string;
+    } else {
+      oldColsArg = JSON.stringify(oldProjectedColumns);
+    }
+    this._args.set( UpdateProjectedColumnsCommand.oldProjectedColumns, oldColsArg );
+
+    if (!id) {
+      //
+      // Generate new id
+      //
+      id = UpdateProjectedColumnsCommand.id + this.idGen;
+    }
+
+    this._args.set( Command.identArg, id);
+  }
+
+  /**
+   * @returns {ProjectedColumns} the new projected columns
+   */
+  public getNewProjectedColumns(): ProjectedColumn[] {
+    const newColsStr = this.getArg( UpdateProjectedColumnsCommand.newProjectedColumns ) as string;
+    const newCols = JSON.parse(newColsStr);
+    const cols: ProjectedColumn[] = [];
+    for (const elem of newCols) {
+      const col: ProjectedColumn = ProjectedColumn.create(elem);
+      cols.push(col);
+    }
+    return cols;
+  }
+
+  /**
+   * @returns {string} json payload for new projected columns
+   */
+  public getNewProjecteColumnsPayload( ): string {
+    return this.getArg( UpdateProjectedColumnsCommand.newProjectedColumns ) as string;
+  }
+
+  /**
+   * @returns {ProjectedColumn[]} the old projected columns
+   */
+  public getOldProjectedColumns(): ProjectedColumn[] {
+    const oldColsStr = this.getArg( UpdateProjectedColumnsCommand.oldProjectedColumns ) as string;
+    const oldCols = JSON.parse(oldColsStr);
+    const cols: ProjectedColumn[] = [];
+    for (const elem of oldCols) {
+      const col: ProjectedColumn = ProjectedColumn.create(elem);
+      cols.push(col);
+    }
+    return cols;
+  }
+
+  /**
+   * @returns {string} json payload for old projected columns
+   */
+  public getOldProjecteColumnsPayload( ): string {
+    return this.getArg( UpdateProjectedColumnsCommand.oldProjectedColumns ) as string;
+  }
+
+  /**
+   * @returns {string} a unique short identifier of this command
+   */
+  public getId( ): string {
+    return this.getArg( Command.identArg ) as string;
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-event.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-event.ts
@@ -106,6 +106,13 @@ export class ViewEditorEvent {
   }
 
   /**
+   * @returns {boolean} `true` if the projected columns editor part was the source of the event
+   */
+  public sourceIsProjectedSymbols(): boolean {
+    return this.source === ViewEditorPart.PROJECTED_COLUMNS;
+  }
+
+  /**
    * @returns {string} a string representation of the event
    */
   public toString(): string {
@@ -238,4 +245,5 @@ export class ViewEditorEvent {
   public typeIsDeleteNode(): boolean {
     return this.type === ViewEditorEventType.DELETE_NODE;
   }
+
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.spec.ts
@@ -26,6 +26,7 @@ import { GraphVisualComponent, LinkVisualComponent, NodeVisualComponent } from "
 import { CanvasService } from "@dataservices/virtualization/view-editor/view-canvas/canvas.service";
 import { SelectionService } from "@core/selection.service";
 import { PropertyEditorComponent } from "@dataservices/virtualization/view-editor/view-property-editors/property-editor/property-editor.component";
+import { ProjectedColumnsEditorComponent } from "@dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component";
 
 describe('ViewCanvasComponent', () => {
   let component: ViewCanvasComponent;
@@ -50,6 +51,7 @@ describe('ViewCanvasComponent', () => {
         GraphVisualComponent,
         LinkVisualComponent,
         NodeVisualComponent,
+        ProjectedColumnsEditorComponent,
         PropertyEditorComponent,
         ViewCanvasComponent,
         ViewPropertyEditorsComponent

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-i18n.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-i18n.ts
@@ -32,6 +32,7 @@ export class ViewEditorI18n {
   public static readonly removeSourcesCommandName = "Remove Sources";
   public static readonly updateViewNameCommandName = "Update View Name";
   public static readonly updateViewDescriptionCommandName = "Update View Description";
+  public static readonly updateProjectedColumnsCommandName = "Update Projected Columns";
 
   // connection table dialog
   public static readonly connectionTableSelectionDialogMessage = "Expand connection and select a source for your view";

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-part.enum.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-part.enum.ts
@@ -43,13 +43,13 @@ export enum ViewEditorPart {
   PREVIEW = "PREVIEW",
 
   /**
-   * The source of the event is the properties part.
+   * The source of the event is the properties editor part.
    */
   PROPERTIES = "PROPERTIES",
 
   /**
-   * The source of the event is the properties part.
+   * The source of the event is the projected columns editor part.
    */
-  COLUMNS = "COLUMNS"
+  PROJECTED_COLUMNS = "PROJECTED_COLUMNS"
 
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.ts
@@ -731,10 +731,7 @@ export class ViewEditorComponent implements DoCheck, OnDestroy, OnInit {
    */
   public get canvasSingleSourceSelected(): boolean {
     const selections = this.editorService.getSelection();
-    if (selections && selections.length === 1) {
-      return true;
-    }
-    return false;
+    return selections && selections.length === 1;
   }
 
 }

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.css
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.css
@@ -1,0 +1,13 @@
+/*
+ * The container for the projected columns editor
+ */
+#projected-columns-editor-container {
+  height: 100%;
+  margin-left: 15px;
+}
+
+.datatable-body-row.active .datatable-row-group {
+  /* background-color: #0088ce !important; */
+  /* border-bottom-color: #00659c !important; */
+  /* color: #fff; */
+}

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.html
@@ -1,0 +1,22 @@
+<div id="projected-columns-editor-container">
+  <div *ngIf="!hasSelectedView">
+    <h3>No View Selected</h3>
+  </div>
+
+  <div *ngIf="hasSelectedView">
+    <h3>View Columns</h3>
+    <!-- View projected columns are '*' -->
+    <div class="col-md-12" *ngIf="hasSelectAllProjectedColumns">
+      <h4>All columns included.  Save the view to populate the specific columns</h4>
+    </div>
+    <!-- Display the table of projected columns -->
+    <div class="col-md-12" *ngIf="!hasSelectAllProjectedColumns">
+      <pfng-table
+        [columns]="tableColumns"
+        [config]="tableConfig"
+        (onSelectionChange)="handleColumnSelectionChange($event)"
+        [rows]="projectedColumns">
+      </pfng-table>
+    </div>
+  </div>
+</div>

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.spec.ts
@@ -1,0 +1,50 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectedColumnsEditorComponent } from './projected-columns-editor.component';
+import { TableModule } from "patternfly-ng";
+import { LoggerService } from "@core/logger.service";
+import { SelectionService } from "@core/selection.service";
+import { AppSettingsService } from "@core/app-settings.service";
+import { MockAppSettingsService } from "@core/mock-app-settings.service";
+import { DataserviceService } from "@dataservices/shared/dataservice.service";
+import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
+import { NotifierService } from "@dataservices/shared/notifier.service";
+import { VdbService } from "@dataservices/shared/vdb.service";
+import { MockVdbService } from "@dataservices/shared/mock-vdb.service";
+import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
+import { HttpModule } from "@angular/http";
+
+describe('ProjectedColumnsEditorComponent', () => {
+  let component: ProjectedColumnsEditorComponent;
+  let fixture: ComponentFixture<ProjectedColumnsEditorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpModule,
+        TableModule
+      ],
+      declarations: [ ProjectedColumnsEditorComponent ],
+      providers: [
+        { provide: AppSettingsService, useClass: MockAppSettingsService },
+        { provide: DataserviceService, useClass: MockDataserviceService },
+        LoggerService,
+        NotifierService,
+        SelectionService,
+        { provide: VdbService, useClass: MockVdbService },
+        ViewEditorService
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProjectedColumnsEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.ts
@@ -1,0 +1,228 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
+import { SelectionService } from "@core/selection.service";
+import { EmptyStateConfig, TableConfig, TableEvent } from "patternfly-ng";
+import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
+import { ProjectedColumn } from "@dataservices/shared/projected-column.model";
+import { CommandFactory } from "@dataservices/virtualization/view-editor/command/command-factory";
+import { Command } from "@dataservices/virtualization/view-editor/command/command";
+import { ViewEditorPart } from "@dataservices/virtualization/view-editor/view-editor-part.enum";
+import { LoggerService } from "@core/logger.service";
+import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
+import { Subscription } from "rxjs/Subscription";
+import { UpdateProjectedColumnsCommand } from "@dataservices/virtualization/view-editor/command/update-projected-columns-command";
+
+@Component({
+  selector: 'app-projected-columns-editor',
+  templateUrl: './projected-columns-editor.component.html',
+  styleUrls: ['./projected-columns-editor.component.css']
+})
+export class ProjectedColumnsEditorComponent implements OnInit, OnDestroy {
+
+  public tableColumns: any[] = [];
+  public tableConfig: TableConfig;
+
+  private readonly editorService: ViewEditorService;
+  private readonly selectionService: SelectionService;
+  private readonly logger: LoggerService;
+  private editorSubscription: Subscription;
+
+  private readonly emptyStateConfig: EmptyStateConfig;
+  public projectedColumns: ProjectedColumn[] = [];
+  private originalColumns: ProjectedColumn[] = [];
+
+  constructor( selectionService: SelectionService,
+               logger: LoggerService,
+               editorService: ViewEditorService ) {
+    this.selectionService = selectionService;
+    this.editorService = editorService;
+    this.logger = logger;
+
+    // ----------------------------------
+    // View Table configurations
+    // ----------------------------------
+    this.tableColumns = [
+      {
+        draggable: false,
+        name: "Name",
+        prop: "name",
+        resizeable: true,
+        sortable: false,
+        width: "60"
+      },
+      {
+        draggable: false,
+        name: "Type",
+        prop: "type",
+        resizeable: true,
+        sortable: false,
+        width: "60"
+      }
+    ];
+
+    this.emptyStateConfig = {
+      title: ViewEditorI18n.noViewsDisplayedMessage
+    } as EmptyStateConfig;
+
+    this.tableConfig = {
+      showCheckbox: true,
+      emptyStateConfig: this.emptyStateConfig,
+    } as TableConfig;
+
+    this.editorService.setEditorVirtualization( selectionService.getSelectedVirtualization() );
+  }
+
+  public ngOnInit(): void {
+    this.editorSubscription = this.editorService.editorEvent.subscribe( ( event ) => this.handleEditorEvent( event ) );
+  }
+
+  /**
+   * Cleanup code when destroying the canvas and properties parts.
+   */
+  public ngOnDestroy(): void {
+    this.editorSubscription.unsubscribe();
+  }
+
+  /**
+   * @param {ViewEditorEvent} event the event being processed
+   */
+  public handleEditorEvent( event: ViewEditorEvent ): void {
+    this.logger.debug( "ProjectedColumnsEditor received event: " + event.toString() );
+
+    // Initialize the projected columns editor when the ViewDefinition is set
+    if ( event.typeIsEditedViewSet()) {
+      const viewDefn = this.editorService.getEditorView();
+      this.initProjectedColumns(viewDefn.getProjectedColumns());
+    }
+    else if (event.typeIsViewStateChanged()) {
+      // Reset project columns if change came from the editor
+      if ( event.sourceIsEditor() ) {
+        if ( event.args.length === 1 && event.args[ 0 ] instanceof Command ) {
+          const cmd = event.args[ 0 ] as Command;
+
+          if ( cmd instanceof UpdateProjectedColumnsCommand ) {
+            this.updateProjectedColumns(cmd.getNewProjectedColumns());
+          }
+        }
+      }
+    }
+    else {
+      this.logger.debug( "ProjectedColumnsEditor not handling received editor event: " + event.toString());
+    }
+  }
+
+  /**
+   * Initializes the projected columns
+   * @param {ProjectedColumn[]} prjCols the projected columns
+   */
+  private initProjectedColumns(prjCols: ProjectedColumn[]): void {
+    this.projectedColumns = [];
+    this.originalColumns = [];
+
+    // Clone view definition projected columns; save original state
+    const copyPrjCols: ProjectedColumn[] = [];
+    const copyOrigCols: ProjectedColumn[] = [];
+    if (prjCols && prjCols !== null) {
+      for (const pCol of prjCols) {
+        copyPrjCols.push(ProjectedColumn.create(pCol));
+        copyOrigCols.push(ProjectedColumn.create(pCol));
+      }
+    }
+    this.projectedColumns = copyPrjCols;
+    this.originalColumns = copyOrigCols;
+
+    this.projectedColumns = [...this.projectedColumns];
+  }
+
+  /**
+   * Updates the projected columns
+   * @param {ProjectedColumn[]} prjCols the projected columns
+   */
+  private updateProjectedColumns(prjCols: ProjectedColumn[]): void {
+    const copyPrjCols: ProjectedColumn[] = [];
+    const copyOrigCols: ProjectedColumn[] = [];
+    if (prjCols && prjCols !== null) {
+      for (const pCol of prjCols) {
+        copyPrjCols.push(ProjectedColumn.create(pCol));
+        copyOrigCols.push(ProjectedColumn.create(pCol));
+      }
+    }
+    this.originalColumns = copyOrigCols;
+    // Handle case where current columns are SELECT *
+    if (this.hasSelectAllProjectedColumns) {
+      // Incoming is also SELECT * - no need to do anything
+      if (this.isSelectStar(copyPrjCols)) {
+        return;
+      }
+      // Incoming is full column set.  Need to remove current SELECT *
+      else {
+        this.projectedColumns = [];
+        for (const col of copyPrjCols) {
+          this.projectedColumns.push(col);
+        }
+      }
+    }
+    // Iterate existing columns, setting selection state
+    else {
+      for (const col of copyPrjCols) {
+        for (const projCol of this.projectedColumns) {
+          if (projCol.getName() === col.getName()) {
+            projCol.selected = col.selected;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Determine if a view has select all projected columns
+   *
+   * @return {boolean} 'true' if view has select all projected columns
+   */
+  public get hasSelectAllProjectedColumns(): boolean {
+    return this.isSelectStar(this.projectedColumns);
+  }
+
+  private isSelectStar(projCols: ProjectedColumn[]): boolean {
+    return projCols && projCols !== null && projCols.length === 1 && projCols[0].getName() === "ALL" && projCols[0].getType() === "ALL";
+  }
+
+  /**
+   * Determine whether the editor has a view currently selected
+   *
+   * @return {boolean} 'true' if has a view selection
+   */
+  public get hasSelectedView(): boolean {
+    const selView = this.editorService.getEditorView();
+    return (selView && selView !== null);
+  }
+
+  /**
+   * Handles change in Column selections
+   * @param {TableEvent} $event the column selection event
+   */
+  public handleColumnSelectionChange($event: TableEvent): void {
+    // Change in projected column selections fire change event
+    if (this.hasSelectedView) {
+      // Fire update event with new and old columns
+      const temp = CommandFactory.createUpdateProjectedColumnsCommand( JSON.stringify(this.projectedColumns), JSON.stringify(this.originalColumns) );
+      if ( temp instanceof Command ) {
+        this.editorService.fireViewStateHasChanged( ViewEditorPart.PROJECTED_COLUMNS, temp as Command );
+      } else {
+        const error = temp as Error;
+        this.logger.error( error.message );
+      }
+      // Update the original columns
+      const origCols: ProjectedColumn[] = [];
+      for (const col of this.projectedColumns) {
+        origCols.push(ProjectedColumn.create(col));
+      }
+      this.originalColumns = origCols;
+    } else {
+      // shouldn't get here as description text input should be disabled if no view being edited
+      this.logger.error( "Trying to set description but there is no view being edited" );
+    }
+  }
+
+}

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.html
@@ -15,5 +15,6 @@
       <span class="pficon pficon-info property-editors-tab-icon"></span>
       <span class="property-editors-tab-heading">{{columnsTabName}}</span>
     </ng-template>
+    <app-projected-columns-editor></app-projected-columns-editor>
   </tab>
 </tabset>

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.spec.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.spec.ts
@@ -14,6 +14,8 @@ import { DataserviceService } from "@dataservices/shared/dataservice.service";
 import { MockDataserviceService } from "@dataservices/shared/mock-dataservice.service";
 import { SelectionService } from "@core/selection.service";
 import { PropertyEditorComponent } from "@dataservices/virtualization/view-editor/view-property-editors/property-editor/property-editor.component";
+import { ProjectedColumnsEditorComponent } from "@dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component";
+import { TableModule } from "patternfly-ng";
 
 describe('ViewPropertyEditorsComponent', () => {
   let component: ViewPropertyEditorsComponent;
@@ -23,9 +25,10 @@ describe('ViewPropertyEditorsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         HttpModule,
+        TableModule,
         TabsModule.forRoot()
       ],
-      declarations: [ PropertyEditorComponent, ViewPropertyEditorsComponent ],
+      declarations: [ ProjectedColumnsEditorComponent, PropertyEditorComponent, ViewPropertyEditorsComponent ],
       providers: [
         { provide: AppSettingsService, useClass: MockAppSettingsService },
         { provide: DataserviceService, useClass: MockDataserviceService },

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/view-property-editors.component.ts
@@ -18,7 +18,6 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { LoggerService } from "@core/logger.service";
 import { ViewEditorI18n } from "@dataservices/virtualization/view-editor/view-editor-i18n";
-import { ViewEditorPart } from "@dataservices/virtualization/view-editor/view-editor-part.enum";
 import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
 import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
 import { Subscription } from "rxjs/Subscription";

--- a/src/main/ngapp/src/app/shared/test-data.service.ts
+++ b/src/main/ngapp/src/app/shared/test-data.service.ts
@@ -1124,7 +1124,54 @@ export class TestDataService {
           "sourcePaths":
             [
               "connection=conn1/schema=public/table=customer"
-            ]
+            ],
+          "projectedColumns": [
+            {
+              "name": "SSN",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "FIRSTNAME",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "LASTNAME",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "ST_ADDRESS",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "APT_NUMBER",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "CITY",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "STATE",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "ZIPCODE",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "PHONE",
+              "type": "string",
+              "selected": false
+            }
+          ]
         }
     }
   );
@@ -1266,7 +1313,54 @@ export class TestDataService {
                 "type": "INNER_JOIN",
                 "operator": "EQ"
               }
-            ]
+            ],
+          "projectedColumns": [
+            {
+              "name": "SSN",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "FIRSTNAME",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "LASTNAME",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "ST_ADDRESS",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "APT_NUMBER",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "CITY",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "STATE",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "ZIPCODE",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "PHONE",
+              "type": "string",
+              "selected": false
+            }
+          ]
         }
     }
   );
@@ -1395,7 +1489,54 @@ export class TestDataService {
           "sourcePaths":
             [
               "connection=conn1/schema=public/table=stuff"
-            ]
+            ],
+          "projectedColumns": [
+            {
+              "name": "SSN",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "FIRSTNAME",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "LASTNAME",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "ST_ADDRESS",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "APT_NUMBER",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "CITY",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "STATE",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "ZIPCODE",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "PHONE",
+              "type": "string",
+              "selected": false
+            }
+          ]
         }
     }
   );
@@ -1537,7 +1678,14 @@ export class TestDataService {
                 "type": "INNER_JOIN",
                 "operator": "EQ"
               }
-            ]
+            ],
+          "projectedColumns": [
+            {
+              "name": "ALL",
+              "type": "ALL",
+              "selected": true
+            }
+          ]
         }
     }
   );
@@ -1679,7 +1827,54 @@ export class TestDataService {
                 "type": "INNER_JOIN",
                 "operator": "EQ"
               }
-            ]
+            ],
+          "projectedColumns": [
+            {
+              "name": "SSN",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "FIRSTNAME",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "LASTNAME",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "ST_ADDRESS",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "APT_NUMBER",
+              "type": "string",
+              "selected": false
+            },
+            {
+              "name": "CITY",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "STATE",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "ZIPCODE",
+              "type": "string",
+              "selected": true
+            },
+            {
+              "name": "PHONE",
+              "type": "string",
+              "selected": false
+            }
+          ]
         }
     }
   );


### PR DESCRIPTION
Initial commit of a projected columns editor panel within the view editor.  This allows the user to narrow the projected columns for a view.
- Added the ProjectedColumnsEditor component - the columns editor tab content.
- Added ProjectedColumn model - the model definition of the projected column
- Updated the ViewDefinition model object - to include the projectedColumns array and also other helper function (to get generate Sql, etc)
- Added UpdateProjectedColumns command.  This is the command which supports undo-redo in the editor for column selection updates.
- updated unit tests
- other changes to fix lint errors