### PR TITLE
TT-465 fix ViewDefinition issue

### DIFF
--- a/src/main/ngapp/src/app/dataservices/shared/view-definition.model.ts
+++ b/src/main/ngapp/src/app/dataservices/shared/view-definition.model.ts
@@ -21,7 +21,6 @@ import { VdbsConstants } from "@dataservices/shared/vdbs-constants";
 import { CompositionOperator } from "@dataservices/shared/composition-operator.enum";
 import { CompositionType } from "@dataservices/shared/composition-type.enum";
 import { ProjectedColumn } from "@dataservices/shared/projected-column.model";
-import { select } from "d3-selection";
 
 /**
  * ViewDefinition model
@@ -34,6 +33,7 @@ export class ViewDefinition {
   private compositions: Composition[] = [];
   private isSelected = false;
   private projectedColumns: ProjectedColumn[] = [];
+  private defaultProjectedColumns: ProjectedColumn[] = [];
 
   /**
    * @param {Object} json the JSON representation of a ViewDefinition
@@ -82,14 +82,15 @@ export class ViewDefinition {
    * Constructor
    */
   constructor() {
-    // The ViewDefinition is initialized with 'SELECT *'
-    const prjCols: ProjectedColumn[] = [];
+    // Define the default projected columns ('SELECT *')
     const selectStar: ProjectedColumn = new ProjectedColumn();
     selectStar.setName("ALL");
     selectStar.setType("ALL");
     selectStar.selected = true;
-    prjCols.push(selectStar);
-    this.setProjectedColumns(prjCols);
+    this.defaultProjectedColumns.push(selectStar);
+
+    // Init the ViewDefinition with default projected columns
+    this.initProjectedColumns();
   }
 
   /**
@@ -132,6 +133,8 @@ export class ViewDefinition {
    */
   public setSourcePaths( sourcePaths: string[] = [] ): void {
     this.sourcePaths = sourcePaths;
+    // change in source paths will re-init the projected columns
+    this.initProjectedColumns();
   }
 
   /**
@@ -146,6 +149,8 @@ export class ViewDefinition {
    */
   public setCompositions( compositions: Composition[] = [] ): void {
     this.compositions = compositions;
+    // change in compositions will re-init the projected columns
+    this.initProjectedColumns();
   }
 
   /**
@@ -186,6 +191,8 @@ export class ViewDefinition {
 
     if ( index === -1 ) {
       this.compositions.push( compositionToAdd );
+      // adding composition will re-init the projected columns
+      this.initProjectedColumns();
     }
   }
 
@@ -197,6 +204,8 @@ export class ViewDefinition {
 
     if ( index !== -1 ) {
       this.compositions.splice( index, 1 );
+      // removing composition will re-init the projected columns
+      this.initProjectedColumns();
     }
   }
 
@@ -212,6 +221,8 @@ export class ViewDefinition {
 
     if ( index === -1 ) {
       this.sourcePaths.push( sourcePathToAdd );
+      // adding source will re-init the projected columns
+      this.initProjectedColumns();
     }
   }
 
@@ -237,6 +248,8 @@ export class ViewDefinition {
 
     if ( index !== -1 ) {
       this.sourcePaths.splice( index, 1 );
+      // remove source will re-init the projected columns
+      this.initProjectedColumns();
     }
   }
 
@@ -380,6 +393,13 @@ export class ViewDefinition {
    */
   public isProjectAllColumns(): boolean {
     return this.getProjectedColumns().length === 1 && this.getProjectedColumns()[0].getName() === "ALL" && this.getProjectedColumns()[0].getType() === "ALL";
+  }
+
+  /**
+   * Initializes the projected columns for this view.  This resets the view projected columns to "*" ("ALL")
+   */
+  private initProjectedColumns(): void {
+    this.setProjectedColumns(this.defaultProjectedColumns);
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.html
@@ -7,7 +7,8 @@
     <h3>View Columns</h3>
     <!-- View projected columns are '*' -->
     <div class="col-md-12" *ngIf="hasSelectAllProjectedColumns">
-      <h4>All columns included.  Save the view to populate the specific columns</h4>
+      <h4>All view columns are included.</h4>
+      <h5>Save the view to populate columns table</h5>
     </div>
     <!-- Display the table of projected columns -->
     <div class="col-md-12" *ngIf="!hasSelectAllProjectedColumns">

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-property-editors/projected-columns-editor/projected-columns-editor.component.ts
@@ -11,6 +11,10 @@ import { LoggerService } from "@core/logger.service";
 import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
 import { Subscription } from "rxjs/Subscription";
 import { UpdateProjectedColumnsCommand } from "@dataservices/virtualization/view-editor/command/update-projected-columns-command";
+import { AddSourcesCommand } from "@dataservices/virtualization/view-editor/command/add-sources-command";
+import { RemoveSourcesCommand } from "@dataservices/virtualization/view-editor/command/remove-sources-command";
+import { AddCompositionCommand } from "@dataservices/virtualization/view-editor/command/add-composition-command";
+import { RemoveCompositionCommand } from "@dataservices/virtualization/view-editor/command/remove-composition-command";
 
 @Component({
   selector: 'app-projected-columns-editor',
@@ -100,8 +104,15 @@ export class ProjectedColumnsEditorComponent implements OnInit, OnDestroy {
         if ( event.args.length === 1 && event.args[ 0 ] instanceof Command ) {
           const cmd = event.args[ 0 ] as Command;
 
+          // Handle updated projected columns
           if ( cmd instanceof UpdateProjectedColumnsCommand ) {
             this.updateProjectedColumns(cmd.getNewProjectedColumns());
+          }
+          // Change in sources or compositions - forces a reset of the columns
+          else if ( cmd instanceof AddSourcesCommand || cmd instanceof RemoveSourcesCommand ||
+                    cmd instanceof AddCompositionCommand || cmd instanceof RemoveCompositionCommand ) {
+            const viewDefn = this.editorService.getEditorView();
+            this.initProjectedColumns(viewDefn.getProjectedColumns());
           }
         }
       }


### PR DESCRIPTION
Fix issues with view definition and projected columns initialization
- ViewDefinition model - now resets the projected columns to 'ALL' whenever there is a change in the sources or compositions.
- ProjectedColumnsEditor - now responds to ViewDefinition source or composition changes and reinits the projected columns table